### PR TITLE
PSReadline history search

### DIFF
--- a/PSFzf.psm1
+++ b/PSFzf.psm1
@@ -379,7 +379,7 @@ function SetPsReadlineShortcut($Chord,[switch]$Override,$BriefDesc,$Desc,[script
 	}
 
 	if ((Get-PSReadlineKeyHandler -Bound | Where Key -eq $Chord) -and -not $Override) {
-		Write-Warning ("PSReadline chord {0} already in use - keyboard handler not installed" -f $Chord)
+		Write-Warning ("PSReadline chord {0} already in use - keyboard handler not installed.  To bind your own keyboard chord, use the -ArgumentList parameter when you call Import-Module." -f $Chord)
 	} else {
 		$script:PSReadlineHandlerChords += $Chord
 		Set-PSReadlineKeyHandler -Key $Chord -Description $Desc -BriefDescription $BriefDesc -ScriptBlock $scriptBlock

--- a/PSFzf.psm1
+++ b/PSFzf.psm1
@@ -372,7 +372,7 @@ function Invoke-FzfPsReadlineHandlerHistory {
 	}
 }
 
-function SetPsReadlineShortcut($Chord,$BriefDesc,$Desc,[scriptblock]$scriptBlock,[switch]$Override)
+function SetPsReadlineShortcut($Chord,[switch]$Override,$BriefDesc,$Desc,[scriptblock]$scriptBlock)
 {
 	if ([string]::IsNullOrEmpty($Chord)) {
 		return
@@ -415,8 +415,8 @@ function FindFzf()
     }
 }
 if (Get-Module -ListAvailable -Name PSReadline) { 
-	SetPsReadlineShortcut "$PSReadlineChordProvider" 'Fzf Provider Select' 'Run fzf for current provider based on current token' { Invoke-FzfPsReadlineHandlerProvider }
-	SetPsReadlineShortcut "$PSReadlineChordReverseHistory" 'Fzf Reverse History Select' 'Run fzf to search through PSReadline history' { Invoke-FzfPsReadlineHandlerHistory } -Override
+	SetPsReadlineShortcut "$PSReadlineChordProvider" -Override:$PSBoundParameters.ContainsKey('PSReadlineChordProvider') 'Fzf Provider Select' 'Run fzf for current provider based on current token' { Invoke-FzfPsReadlineHandlerProvider }
+	SetPsReadlineShortcut "$PSReadlineChordReverseHistory" -Override:$PSBoundParameters.ContainsKey('PSReadlineChordReverseHistory') 'Fzf Reverse History Select' 'Run fzf to search through PSReadline history' { Invoke-FzfPsReadlineHandlerHistory }
 } else {
 	Write-Warning "PSReadline module not found - keyboard handlers not installed" 
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PSFzf does not override <kbd>CTRL+R</kbd> by default.  To confirm that you want 
 The first option is to remove the handler from PSReadline.  For example:
 
 ```powershell
-Remove-PSReadlineKeyHandler CTRL+R
+Remove-PSReadlineKeyHandler 'CTRL+R'
 Import-Module PSFzf
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,20 @@ Get-ChildItem . -Recurse | where { -not $_.PSIsContainer } | Invoke-Fzf | % { no
 For day-to-day usage, see the [helper functions included with this module](https://github.com/kelleyma49/PSFzf#helper-functions).
 
 ## PSReadline Integration
-Press <kbd>CTRL+T</kbd> to start PSFzf.  PSFzf will parse the current token and use that as the starting path to search from.  If current token is empty, or the token isn't a valid path, PSFzf will search below the current working directory.  
+### Select Current Provider Path (default chord: <kbd>CTRL+T</kbd>) 
+Press <kbd>CTRL+T</kbd> to start PSFzf to select provider paths.  PSFzf will parse the current token and use that as the starting path to search from.  If current token is empty, or the token isn't a valid path, PSFzf will search below the current working directory.  
 
-Multiple items can be selected in PSFzf.  If more than one it is selected by the user, the results are returned as a comma separated list.  Results are properly quoted if they contain whitespace.
+Multiple items can be selected.  If more than one it is selected by the user, the results are returned as a comma separated list.  Results are properly quoted if they contain whitespace.
 
+### Reverse Search Through PSReadline History (default chord: <kbd>CTRL+R</kbd>)
+
+PSFzf does not override <kbd>CTRL+R</kbd> by default.  To confirm that you want to override PSReadline's chord binding, you must pass in the chord when you import the module.  For example:
+
+```powershell
+Import-Module PSFzf -ArgumentList 'Ctrl+T','Ctrl+R' # or replace these strings with your preferred bindins
+``` 
+
+Press <kbd>CTRL+R</kbd> to start PSFzf to select a command in the command history saved by PSReadline.  PSFzf will insert the command into the current line, but it will not execute the command.
 ## Using within a Pipeline
 `Invoke-Fzf` works with input from a pipeline.  However, if you make your selection before fzf has finished receiving and parsing from standard in, you might see a ```Stopped pipeline input``` error.  This is because PSFzf must throw an exception to cancel pipeline processing.  If you pipe the output of `Invoke-Fzf` to whatever action you wish to do based on your selection, the action will occur.  The following will not work if the pipeline is cancelled:
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,23 @@ Multiple items can be selected.  If more than one it is selected by the user, th
 
 ### Reverse Search Through PSReadline History (default chord: <kbd>CTRL+R</kbd>)
 
-PSFzf does not override <kbd>CTRL+R</kbd> by default.  To confirm that you want to override PSReadline's chord binding, you must pass in the chord when you import the module.  For example:
+Press <kbd>CTRL+R</kbd> to start PSFzf to select a command in the command history saved by PSReadline.  PSFzf will insert the command into the current line, but it will not execute the command.
+
+PSFzf does not override <kbd>CTRL+R</kbd> by default.  To confirm that you want to override PSReadline's chord binding, you have two options.
+
+The first option is to remove the handler from PSReadline.  For example:
 
 ```powershell
-Import-Module PSFzf -ArgumentList 'Ctrl+T','Ctrl+R' # or replace these strings with your preferred bindins
+Remove-PSReadlineKeyHandler CTRL+R
+Import-Module PSFzf
+```
+
+The other option is to pass in the chord when you import the module.  For example:
+
+```powershell
+Import-Module PSFzf -ArgumentList 'Ctrl+T','Ctrl+R' # or replace these strings with your preferred bindings
 ``` 
 
-Press <kbd>CTRL+R</kbd> to start PSFzf to select a command in the command history saved by PSReadline.  PSFzf will insert the command into the current line, but it will not execute the command.
 ## Using within a Pipeline
 `Invoke-Fzf` works with input from a pipeline.  However, if you make your selection before fzf has finished receiving and parsing from standard in, you might see a ```Stopped pipeline input``` error.  This is because PSFzf must throw an exception to cancel pipeline processing.  If you pipe the output of `Invoke-Fzf` to whatever action you wish to do based on your selection, the action will occur.  The following will not work if the pipeline is cancelled:
 


### PR DESCRIPTION
Ctrl+R uses fzf instead of calling the
ReverseSearchHistory command in
PSReadline