### PR TITLE
Fix usage of Search-Everything for setting location

### DIFF
--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -104,9 +104,16 @@ Set-Alias -Name fd -Value Invoke-FuzzySetLocation
 if (Get-Command Search-Everything -ErrorAction SilentlyContinue) {
     #.ExternalHelp PSFzf.psm1-help.xml
     function Set-LocationFuzzyEverything() {
+        param($Directory=$null)
+        if ($Directory -eq $null) {
+            $Directory = $PWD.Path
+            $Global = $False
+        } else {
+            $Global = $True
+        }
         $result = $null
         try {
-            Search-Everything -FolderInclude @('') | Invoke-Fzf | ForEach-Object { $result = $_ }
+            Search-Everything -Global:$Global -PathInclude $Directory -FolderInclude @('') | Invoke-Fzf | ForEach-Object { $result = $_ }
         } catch {
             
         }

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -106,7 +106,7 @@ if (Get-Command Search-Everything -ErrorAction SilentlyContinue) {
     function Set-LocationFuzzyEverything() {
         $result = $null
         try {
-            Search-Everything | Invoke-Fzf | ForEach-Object { $result = $_ }
+            Search-Everything -FolderInclude @('') | Invoke-Fzf | ForEach-Object { $result = $_ }
         } catch {
             
         }

--- a/docs/Set-LocationFuzzyEverything.md
+++ b/docs/Set-LocationFuzzyEverything.md
@@ -9,7 +9,7 @@ Sets the current location based on the Everything database.
 ## SYNTAX
 
 ```
-Set-LocationFuzzyEverything
+Set-LocationFuzzyEverything [-Directory <string>]
 ```
 
 ## DESCRIPTION
@@ -25,7 +25,30 @@ Launches fzf and sets the current location based on the user selection.
 Set-LocationFuzzyEverything
 ```
 
+### Launch Set-LocationFuzzyEverything specifying a path filter
+  
+Launches fzf for all subdirectories of c:\Windows and sets the current location based on the user selection.
+
+
+```
+Set-LocationFuzzyEverything c:\Windows
+```
+
 ## PARAMETERS
+### -Directory
+The path to a directory that contains the subdirectories that the user will choose from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 This cmdlet does not support common parameters.


### PR DESCRIPTION
Make Search-Everything only search for directories: this is faster and
avoids errors when selecting a file from the matches since these cannot
be cd'ed to anyway.
Also add a directory argument for selecting the initial directory (this eventually
uses Everything's `path:` so can be used to specify starting directory or partial match),
making it more versatile as it allows starting the search in another directory than the
current one and makes it a much faster alternative to Invoke-FuzzySetLocation.
For a directory with about 10000 subdirectories, `cde somedir` is instant while `fd somedir` takes 10 seconds.