### PR TITLE
Respect PsReadline's HistoryNoDuplicates setting

### DIFF
--- a/PSFzf.psm1
+++ b/PSFzf.psm1
@@ -378,16 +378,21 @@ function Invoke-FzfPsReadlineHandlerProvider {
 }
 function Invoke-FzfPsReadlineHandlerHistory {
 	$result = $null
-    try 
-    {
-		Get-Content (Get-PSReadlineOption).HistorySavePath | Invoke-Fzf -NoSort -ReverseInput | ForEach-Object { $result = $_ }
+	try
+	{
+		if ((Get-PSReadlineOption).HistoryNoDuplicates) {
+			$modifier = { $input | Select-Object -Unique }
+		} else {
+			$modifier = { process { $_ } }
+		}
+		Get-Content (Get-PSReadlineOption).HistorySavePath | & $modifier | Invoke-Fzf -NoSort -ReverseInput | ForEach-Object { $result = $_ }
 	}
-	catch 
+	catch
 	{
 		# catch custom exception
 	}
 	if (-not [string]::IsNullOrEmpty($result)) {
-	  	[Microsoft.PowerShell.PSConsoleReadLine]::Insert($result)
+		[Microsoft.PowerShell.PSConsoleReadLine]::Insert($result)
 	}
 }
 


### PR DESCRIPTION
If a user has chosen to ignore duplicates in the Psreadline history,
apply this to the history shown by Invoke-FzfPsReadlineHandlerHistory as
well for consistency since it will usually used in place of the original
PsReadLine hisotroy search.
Note that PsReadLine ignores duplicates in code, not in the file it saves,
so we must do the same by filtering duplicates from the file.

Note I replaces some spaces with tabs in this function to keep things readable.