### PR TITLE
Don't list files if Invoke-FzfPsReadlineHandlerProvider command conta…

### DIFF
--- a/PSFzf.psm1
+++ b/PSFzf.psm1
@@ -340,10 +340,15 @@ function Invoke-FzfPsReadlineHandlerProvider {
             if ($resolvedPath -ne $null) {
                 $providerName = $resolvedPath.Provider.Name 
             }
+            if ($line.TrimStart().StartsWith('cd ')) {
+              $dirCmd = 'dir /s /b /ad "{0}"'
+            } else {
+              $dirCmd = $script:DefaultFileSystemCmd
+            }
             switch ($providerName) {
                 # Get-ChildItem is way too slow - we optimize for the FileSystem provider by 
                 # using batch commands:
-                'FileSystem'    { Invoke-Expression ($script:ShellCmd -f ($script:DefaultFileSystemCmd -f $resolvedPath.ProviderPath)) | Invoke-Fzf -Multi | ForEach-Object { $result += $_ } }
+                'FileSystem'    { Invoke-Expression ($script:ShellCmd -f ($dirCmd -f $resolvedPath.ProviderPath)) | Invoke-Fzf -Multi | ForEach-Object { $result += $_ } }
                 'Registry'      { Get-ChildItem $currentPath -Recurse -ErrorAction SilentlyContinue | Select-Object Name -ExpandProperty Name | Invoke-Fzf -Multi | ForEach-Object { $result += $_ } }
                 $null           { Get-ChildItem $currentPath -Recurse -ErrorAction SilentlyContinue | Select-Object FullName -ExpandProperty FullName | Invoke-Fzf -Multi | ForEach-Object { $result += $_ } }
                 Default         {}


### PR DESCRIPTION
…ins cd

If the commandline already has a 'cd' command it's no use listing files
since the user cannot cd to them. With this patch, entering
'cd <some/dir> Ctrl-T' will result in fzf being launched only for the
subdirectories of some/dir, not for the files.