### PR TITLE
Fix sort order when listing history without duplicates

### DIFF
--- a/PSFzf.psm1
+++ b/PSFzf.psm1
@@ -390,11 +390,12 @@ function Invoke-FzfPsReadlineHandlerHistory {
 	try
 	{
 		if ((Get-PSReadlineOption).HistoryNoDuplicates) {
-			$modifier = { $input | Select-Object -Unique }
+			$history = Get-Content (Get-PSReadlineOption).HistorySavePath
+			[array]::reverse($history)
+			$history | Select-Object -Unique | Invoke-Fzf -NoSort | ForEach-Object { $result = $_ }
 		} else {
-			$modifier = { process { $_ } }
+			Get-Content (Get-PSReadlineOption).HistorySavePath | Invoke-Fzf -NoSort -ReverseInput | ForEach-Object { $result = $_ }
 		}
-		Get-Content (Get-PSReadlineOption).HistorySavePath | & $modifier | Invoke-Fzf -NoSort -ReverseInput | ForEach-Object { $result = $_ }
 	}
 	catch
 	{


### PR DESCRIPTION
Select-Object -Unique walks the input from top to bottom, which means
if we put in @(a, b, c, a) the output is @(a, b, c). This is unwanted
here because we're listing history and want the most recent commands to
turn up first, and in this case 'first' means at the bottom of the list;
in other words we want @(b, c, a) as output.
Fix this by reversing the history lines before removing duplicates.