### PR TITLE
Ignore PSFzf.dll on root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,5 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+PSFzf.dll


### PR DESCRIPTION
I'm installing the tool using git submodules, and I build it if I need it, but the directory shows dirty because PSFzf.dll is not ignored. Adding this allows this workflow to work.