### PR TITLE
Tab expansion improvements

### DIFF
--- a/PSFzf.TabExpansion.ps1
+++ b/PSFzf.TabExpansion.ps1
@@ -12,12 +12,11 @@ function Expand-FileDirectoryPath($lastWord) {
             if ($lastWord.EndsWith('\')) {
                 $dir = $lastWord.Substring(0, $lastWord.Length - 1)
                 $file = $null    
-            }
-            else {
+            } elseif (-not [string]::IsNullOrWhiteSpace($lastWord)) {
                 $dir = Split-Path $lastWord -Parent
                 $file = Split-Path $lastWord -Leaf    
             }
-            if (-not [System.IO.Path]::IsRooted($dir)) {
+            if (-not [System.IO.Path]::IsPathRooted($dir)) {
                 $dir = Join-Path $PWD.Path $dir
             }
             $prevPath = $Pwd.Path

--- a/PSFzf.TabExpansion.ps1
+++ b/PSFzf.TabExpansion.ps1
@@ -24,7 +24,11 @@ function Expand-GitWithFzf($lastBlock) {
     if ($results.Count -gt 1) {
         $results -join ' '
     } else {
-        $results
+        if (-not $null -eq $results) {
+            $results
+        } else {
+            '' # output something to prevent default tab expansion
+        }
     }
 
     #HACK: workaround for fact that PSReadLine seems to clear screen 

--- a/PSFzf.TabExpansion.ps1
+++ b/PSFzf.TabExpansion.ps1
@@ -33,34 +33,37 @@ function Expand-GitWithFzf($lastBlock) {
 }
 
 function Expand-FileDirectoryPath($lastWord) {
-            # find dir and file pattern connected to the trigger:
-            $lastWord = $lastWord.Substring(0, $lastWord.Length - 2)
-            if ($lastWord.EndsWith('\')) {
-                $dir = $lastWord.Substring(0, $lastWord.Length - 1)
-                $file = $null    
-            } elseif (-not [string]::IsNullOrWhiteSpace($lastWord)) {
-                $dir = Split-Path $lastWord -Parent
-                $file = Split-Path $lastWord -Leaf    
-            }
-            if (-not [System.IO.Path]::IsPathRooted($dir)) {
-                $dir = Join-Path $PWD.Path $dir
-            }
-            $prevPath = $Pwd.Path
-            try {
-                if (-not [string]::IsNullOrEmpty($dir)) {
-                    Set-Location $dir
-                }
-                if (-not [string]::IsNullOrEmpty($file)) {
-                    Invoke-Fzf -Query $file
-                }
-                else {
-                    Invoke-Fzf
-                }
-            }
-            finally {
-                Set-Location $prevPath
-            }
+    # find dir and file pattern connected to the trigger:
+    $lastWord = $lastWord.Substring(0, $lastWord.Length - 2)
+    if ($lastWord.EndsWith('\')) {
+        $dir = $lastWord.Substring(0, $lastWord.Length - 1)
+        $file = $null    
+    } elseif (-not [string]::IsNullOrWhiteSpace($lastWord)) {
+        $dir = Split-Path $lastWord -Parent
+        $file = Split-Path $lastWord -Leaf    
+    }
+    if (-not [System.IO.Path]::IsPathRooted($dir)) {
+        $dir = Join-Path $PWD.Path $dir
+    }
+    $prevPath = $Pwd.Path
+    try {
+        if (-not [string]::IsNullOrEmpty($dir)) {
+            Set-Location $dir
+        }
+        if (-not [string]::IsNullOrEmpty($file)) {
+            Invoke-Fzf -Query $file
+        }
+        else {
+            Invoke-Fzf
+        }
+    }
+    finally {
+        Set-Location $prevPath
+    }
 
+    #HACK: workaround for fact that PSReadLine seems to clear screen 
+    # after keyboard shortcut action is executed:
+    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
 }
 
 function TabExpansion($line, $lastWord) {


### PR DESCRIPTION

- combine multiple results into a single string
- invoke fzf by itself if no results are returned from Expand-GitCommand
- add InvokePrompt workaround after fzf is invoked