### PR TITLE
Fixed bat command

### DIFF
--- a/helpers/PsFzfTabExpansion-Preview.ps1
+++ b/helpers/PsFzfTabExpansion-Preview.ps1
@@ -32,7 +32,7 @@ if (Test-Path $path -PathType Container) {
 elseif (Test-Path $path -PathType leaf) {
     # use bat (https://github.com/sharkdp/bat) if it's available:
     if ($ansiCompatible -and $(Get-Command bat -ErrorAction SilentlyContinue)) {
-        bat --style=numbers,changes --color always $path
+        bat "--style=numbers,changes" --color always $path
     } else {
         Get-Content $path
     }


### PR DESCRIPTION
without the quotes, bat interprets "changes" as a name of a file and displays an error (at least on my machine)