### PR TITLE
Fix working directory condition

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -311,7 +311,7 @@ function Invoke-Fzf {
         $process.StartInfo.RedirectStandardInput = $true
         $process.StartInfo.RedirectStandardOutput = $true
 		$process.StartInfo.UseShellExecute = $false
-		if ($pwd.Provider -eq 'FileSystem') {
+		if ($pwd.Provider.Name -eq 'FileSystem') {
 			$process.StartInfo.WorkingDirectory = $pwd.Path
 		}
         


### PR DESCRIPTION
Working directory was not getting set correctly as this condition was always false. We need to compare the `Name` property of Provider.

Tested on Windows, Linux and macOS.

Closes #65 