### PR TITLE
fix: invoke-fuzzyedit directory resolve

### DIFF
--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -38,7 +38,7 @@ function Invoke-FuzzyEdit()
             $prevDir = $PWD.Path
             cd $Directory
         }
-        Invoke-Expression (Get-FileSystemCmd .) | Invoke-Fzf -Multi | ForEach-Object { $files += """$_""" }
+        Invoke-Expression (Get-FileSystemCmd .) | Invoke-Fzf -Multi | ForEach-Object { $files += "$_" }
     } catch {
     }
     finally {
@@ -64,16 +64,23 @@ function Invoke-FuzzyEdit()
         }
     }
     
-    if ($null -ne $files) {
-        $fileList = ''
-        $files | ForEach-Object {
+    if ($files.Count -gt 0) {
+        try {
             if ($Directory) {
-                $fileList += (Join-Path $Directory $_) + ' '
-            } else {
-                $fileList += $_ + ' '
+                $prevDir = $PWD.Path
+                cd $Directory
+            }
+            # Not sure if being passed relative or absolute path
+            $fileList = '"{0}"' -f ( (Resolve-Path $files) -join '" "' )
+            Invoke-Expression -Command ("$editor $editorOptions $fileList") 
+        }
+        catch {
+        }
+        finally {
+            if ($prevDir) {
+                cd $prevDir
             }
         }
-        Invoke-Expression -Command ("$editor $editorOptions $fileList") 
     }
 }
 


### PR DESCRIPTION
### Commit Message
join-path replaced with resolve-path to handle absolute or relative paths.
dir outputs absolute paths while find/fd output relative paths.
also fixed $files check for Count instead of $null, because
the variable is instantiated as an empty array and therefore
isn't $null

Closes #99 