### PR TITLE
Do not abort when failing to flush a stream

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -491,7 +491,13 @@ function Invoke-Fzf {
 			}
 		}
 		if ($null -ne $utf8Stream) {
-			$utf8Stream.Flush()
+			try {
+				$utf8Stream.Flush()
+			} catch {
+				# Error when flushing the stream should not cause a pipeline
+				# to exit. In particular, we will get a 'broken pipe' error
+				# here when accepting selection early on Linux. See #112.
+			}
 		}
 	}
 


### PR DESCRIPTION
Exception during stream flush would abort the pipeline and fail to
properly process any result of selection when using Alt+c or Ctrl+t
functionality, for example.

This *will* happen on Linux when accepting the selection early, before
the earlier step finishes streaming input and if it is a system command
rather than powershell cmdlet.

Fixes #112.