### PR TITLE
Ansi Console support And FuzzyEdit

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -23,7 +23,7 @@ find -L '{0}' -path '*/\.*' -prune -o -type d -print 2> /dev/null
 "@
 }
 
-$script:RunningInWindowsTerminal = [bool]($env:WT_Session)
+$script:RunningInWindowsTerminal = [bool]($env:WT_Session) -or [bool]($env:ConEmuANSI)
 if ($script:RunningInWindowsTerminal) {
 	$script:DefaultFileSystemFdCmd = "fd.exe --color always . `"{0}`""
 } else {

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -57,6 +57,7 @@ function Invoke-FuzzyEdit()
     # HACK to check to see if we're running under Visual Studio Code.
     # If so, reuse Visual Studio Code currently open windows:
     $editorOptions = ''
+	$editorOptions += $FzfUserEditorOptions
     if ($null -ne $env:VSCODE_PID) {
         $editor = 'code'
         $editorOptions += '--reuse-window'

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -34,11 +34,18 @@ function Invoke-FuzzyEdit()
 
     $files = @()
     try {
-        if ($Directory) {
-            $prevDir = $PWD.ProviderPath
-            cd $Directory
-        }
-        Invoke-Expression (Get-FileSystemCmd .) | Invoke-Fzf -Multi | ForEach-Object { $files += "$_" }
+		if( Test-Path $Directory){
+			if( (Get-Item $Directory).PsIsContainer ) {
+				if ($Directory) {
+					$prevDir = $PWD.ProviderPath
+					cd $Directory
+				}
+				Invoke-Expression (Get-FileSystemCmd .) | Invoke-Fzf -Multi | ForEach-Object { $files += "$_" }
+			}else {
+				$files+=$Directory
+				$Directory = Split-Path -Parent $Directory
+			}
+		}
     } catch {
     }
     finally {

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -60,7 +60,7 @@ function Invoke-FuzzyEdit()
         $editor = 'code'
         $editorOptions += '--reuse-window'
     } else {
-        $editor = ($env:EDITOR && $env:VISUAL)
+        $editor = if($ENV:VISUAL){$ENV:VISUAL}elseif($ENV:EDITOR){$ENV:EDITOR} 
         if ($null -eq $editor) {
             if (!$IsWindows) {
                 $editor = 'vim'

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -61,7 +61,7 @@ function Invoke-FuzzyEdit()
         $editor = 'code'
         $editorOptions += '--reuse-window'
     } else {
-        $editor = $env:EDITOR
+        $editor = ($env:EDITOR && $env:VISUAL)
         if ($null -eq $editor) {
             if (!$IsWindows) {
                 $editor = 'vim'

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -30,16 +30,14 @@ function script:RemovePsFzfAliases {
 }
 function Invoke-FuzzyEdit()
 {
-    param($Directory=$null)
+    param($Directory=".")
 
     $files = @()
     try {
 		if( Test-Path $Directory){
 			if( (Get-Item $Directory).PsIsContainer ) {
-				if ($Directory) {
-					$prevDir = $PWD.ProviderPath
-					cd $Directory
-				}
+				$prevDir = $PWD.ProviderPath
+				cd $Directory
 				Invoke-Expression (Get-FileSystemCmd .) | Invoke-Fzf -Multi | ForEach-Object { $files += "$_" }
 			}else {
 				$files+=$Directory


### PR DESCRIPTION
Console :
- Activate ANSI Compatibility (WindowsTerminal) when using ConEmu ( https://github.com/Maximus5/ConEmu )

FuzzyEdit : 
Maybe somes options are very specific for my use 
- FuzzyEdit Directly open File when arguments is a file 
- Default editor can be set in env EDITOR ou env VISUAL
- Allow user to pass options to editor 
ex : Vim allow to open multiple files in Tab (-p), HSplit (-o), VSplit (-O)
