### PR TITLE
Use Double quotes instead of single

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -99,8 +99,19 @@ class FzfDefaultCmd {
 
 function FixCompletionResult($str)
 {
-	if ($str.Contains(" ") -or $str.Contains("`t")) {
-		return "'{0}'" -f $str.Replace("`r`n","").Trim(@('''','"'))
+	if ([string]::IsNullOrEmpty($str)) {
+		return ""
+	}
+	elseif ($str.Contains(" ") -or $str.Contains("`t")) {
+		$str = $str.Replace("`r`n","")
+		# check if already quoted
+		if (($str.StartsWith("'") -and $str.EndsWith("'")) -or `
+			($str.StartsWith("""") -and $str.EndsWith(""""))) {
+				return $str
+			} else {
+				return """{0}""" -f $str
+			}
+
 	} else {
 		return $str.Replace("`r`n","")
 	}

--- a/PSFzf.tests.ps1
+++ b/PSFzf.tests.ps1
@@ -124,6 +124,38 @@ Describe "Add-BinaryModuleTypes" {
 	}
 }
 
+Describe "Check FixCompletionResult" {
+	InModuleScope PsFzf {
+		Context "Non-quoted Strings Should Not Change" {
+			It "Check Simple String" {
+				FixCompletionResult("not_quoted") | Should -Be "not_quoted"
+			}
+			It "Check Simple String with quote" {
+				FixCompletionResult("not_quotedwith'") | Should -Be "not_quotedwith'"
+			}
+		}
+
+		Context "Non-quoted Strings With Spaces Should Change" {
+			It "Check Simple String With Space" {
+				FixCompletionResult("with space") | Should -Be """with space"""
+			}
+			It "Check Simple String with quote" {
+				FixCompletionResult("with space, ' and with'") | Should -Be """with space, ' and with'"""
+			}
+		}
+
+		Context "Quoted Strings Should Not Change" {
+			It "Check Simple String With Space and Already Double Quoted" {
+				FixCompletionResult("""with space and already quoted""") | Should -Be """with space and already quoted"""
+			}
+
+			It "Check Simple String With Space and Already Single Quoted" {
+				FixCompletionResult("'with space and already quoted'") | Should -Be "'with space and already quoted'"
+			}
+		}
+	}
+}
+
 Describe "Check Parameters" {
 	InModuleScope PsFzf {
 		Context "Parameters Should Fail" {


### PR DESCRIPTION
- FixCompletionResult will use double quotes to quote string instead of single in case file name as a single quote in the name
- Add unit tests for FixCompletionResult
- Resolves #171
