### PR TITLE
✨ Handle a scoop installation of git

### DIFF
--- a/PSFzf.Git.ps1
+++ b/PSFzf.Git.ps1
@@ -39,6 +39,15 @@ function SetupGitPaths() {
             $gitInfo = Get-Command git.exe -ErrorAction SilentlyContinue
             $script:foundGit = $null -ne $gitInfo
             if ($script:foundGit) {
+                # Detect if scoop is installed
+                $script:scoopInfo = Get-Command scoop -ErrorAction SilentlyContinue
+                if ($null -ne $script:scoopInfo) {
+                    # Detect if git is installed using scoop (using shims)
+                    if ((Split-Path $gitInfo.Source -Parent) -eq (Split-Path (Get-Command scoop).Source -Parent)) {
+                        # Get the proper git position relative to scoop shims" position
+                        $gitInfo = Get-Command "$($gitInfo.Source)\..\..\apps\git\current\bin\git.exe"
+                    }
+                }
                 $gitPathLong = Split-Path (Split-Path $gitInfo.Source -Parent) -Parent
                 # hack to get short path:
                 $a = New-Object -ComObject Scripting.FileSystemObject

--- a/PSFzf.Git.ps1
+++ b/PSFzf.Git.ps1
@@ -43,7 +43,7 @@ function SetupGitPaths() {
                 $script:scoopInfo = Get-Command scoop -ErrorAction SilentlyContinue
                 if ($null -ne $script:scoopInfo) {
                     # Detect if git is installed using scoop (using shims)
-                    if ((Split-Path $gitInfo.Source -Parent) -eq (Split-Path (Get-Command scoop).Source -Parent)) {
+                    if ((Split-Path $gitInfo.Source -Parent) -eq (Split-Path $script:scoopInfo.Source -Parent)) {
                         # Get the proper git position relative to scoop shims" position
                         $gitInfo = Get-Command "$($gitInfo.Source)\..\..\apps\git\current\bin\git.exe"
                     }


### PR DESCRIPTION
I used `scoop` to install `git` (and `fzf` and `PSFzf`) but since it uses shims it seems that `PSFzf` is unable to find `bash` and `grep` for the `git` key bindings.
I quickly hacked together a simple fix that should work in most cases (for example when `scoop` is not installed at the default location).
I built it and tested the fix on my computer and it should be working fine.