### PR TITLE
Make sorting by relevance the default behavior

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -774,7 +774,7 @@ function Invoke-FzfPsReadlineHandlerHistory {
 				$fileHist.Add($_,$true)
 				$_
 			}
-		} | Invoke-Fzf -NoSort -Query "$line" -Bind ctrl-r:toggle-sort | ForEach-Object { $result = $_ }
+		} | Invoke-Fzf -Query "$line" -Bind ctrl-r:toggle-sort | ForEach-Object { $result = $_ }
 	}
 	catch
 	{


### PR DESCRIPTION
Nowadays, the default method of sorting in fzf when pressing <kbd>Ctrl+r</kbd> is by relevance and not chronological order ([c387689](https://github.com/junegunn/fzf/commit/c387689d1cd45f0d8eb122fe95ee72ccc61d3bff)). If the user wishes to see the commands in chronological order they must either press <kbd>Ctrl+r</kbd> again or add `--no-sort` to `FZF_CTRL_R_OPTS`.

The function `Invoke-FzfPsReadlineHandlerHistory()` currently passes the `-NoSort` argument whenever it is called, thus making fzf always sort by chronological order, even if we add `--sort` to `FZF_CTRL_R_OPTS`. I propose this argument should be removed, letting the user decide, by adding or not `--no-sort` to `FZF_CTRL_R_OPTS`, how they wish to order their results and making PSFzf's default behavior equal to fzf's.