### PR TITLE
The scoop default command is ending with *.cmd

### DIFF
--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -296,7 +296,6 @@ function Invoke-FuzzyScoop() {
     $result = $null
     $scoopexists = Get-Command scoop -ErrorAction Ignore
 	if (-not $scoopexists.Path) {
-		Write-Host "yes"
 		$scoopexists = Get-Command scoop.cmd -ErrorAction Ignore
 	}
 

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -295,6 +295,11 @@ function Invoke-FuzzyScoop() {
 
     $result = $null
     $scoopexists = Get-Command scoop -ErrorAction Ignore
+	if (-not $scoopexists.Path) {
+		Write-Host "yes"
+		$scoopexists = Get-Command scoop.cmd -ErrorAction Ignore
+	}
+
     if ($scoopexists) {
         $apps = New-Object System.Collections.ArrayList
         Get-ChildItem "$(Split-Path $scoopexists.Path)\..\buckets" | ForEach-Object {


### PR DESCRIPTION
The problem that I'm having with using the scoop commands (aliases & invokes) are the same as in the screenshot:
![2022-12-07 00_07_52-PSFzf psm1 - Visual Studio Code](https://user-images.githubusercontent.com/1382421/206044486-cf1cbf6b-b685-4208-8cd3-237e05debf02.png)
The change adds the additional checking for Path and for the *.cmd command.