### PR TITLE
Update PSFzf.Base.ps1 to return a full path

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -656,7 +656,7 @@ function Invoke-FzfDefaultSystem {
 		Get-Event -SourceIdentifier $stdOutEventId | `
 			Sort-Object -Property TimeGenerated | `
 			Where-Object { $null -ne $_.SourceEventArgs.Data } | ForEach-Object {
-				$result += $_.SourceEventArgs.Data
+				$result += [System.IO.Path]::Join($ProviderPath, $_.SourceEventArgs.Data)
 				Remove-Event -EventIdentifier $_.EventIdentifier
 			}
 		Remove-Event -SourceIdentifier $stdOutEventId


### PR DESCRIPTION
Return a full path for the selected item on <Ctrl+t>. This solves the problem when the function is invoked with path, e.g. invoking it in current directory works fine, but when doing something like this: "ls C:\Path\<Ctrl+t>" and selecting an item, will end up with "ls Sub-path".