### PR TITLE
PSFzf.Base.ps1: enhance <Ctrl+t> functionality

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -672,6 +672,11 @@ function Invoke-FzfDefaultSystem {
 			$script:OverrideFzfDefaultOpts = $null
 		}
 	}
+	if ((Join-Path $PWD '') -ne (Join-Path $ProviderPath '')) {
+		for ($i = 0;$i -lt $result.Length;$i++) {
+			$result[$i] = Join-Path $ProviderPath $result[$i]
+		}
+	}
 
 	return $result
 }


### PR DESCRIPTION
Return a full path for the selected item on <Ctrl+t>. This solves the problem when the function is invoked with path, e.g. invoking it in current directory works fine, but when doing something like this: "ls C:\Path<Ctrl+t>" and selecting an item, will end up with "ls Sub-path". This change addresses the issue.