### PR TITLE
Don't use FZF_DEFAULT_COMMAND

### DIFF
--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -229,12 +229,7 @@ function Invoke-FuzzySetLocation() {
     if ($null -eq $Directory) { $Directory = $PWD.ProviderPath }
     $result = $null
     try {
-        if ([string]::IsNullOrWhiteSpace($env:FZF_DEFAULT_COMMAND)) {
-            Get-ChildItem $Directory -Recurse -ErrorAction Ignore | Where-Object { $_.PSIsContainer } | Invoke-Fzf | ForEach-Object { $result = $_ }
-        }
-        else {
-            Invoke-Fzf | ForEach-Object { $result = $_ }
-        }
+        Get-ChildItem $Directory -Recurse -ErrorAction Ignore | Where-Object { $_.PSIsContainer } | Invoke-Fzf | ForEach-Object { $result = $_ }
     }
     catch {
 


### PR DESCRIPTION
- Invoke-FuzzySetLocation no longer uses FZF_DEFAULT_COMMAND to ensure
proper directory selection
- Fixes #229
