### PR TITLE
Change PSEverything URL to point to repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ PSFzf is available on the [PowerShell Gallery](https://www.powershellgallery.com
 
 * [`Invoke-FuzzyFasd`](docs/Invoke-FuzzyFasd.md) requires [Fasdr](https://github.com/kelleyma49/fasdr) to be previously installed under Windows.  Other platforms require [Fasd](https://github.com/clvv/fasd) to be installed.
 * [`Invoke-FuzzyZLocation`](docs/Invoke-FuzzyZLocation.md) requires [ZLocation](https://github.com/vors/ZLocation) and works only under Windows.
-* [`Set-LocationFuzzyEverything`](docs/Set-LocationFuzzyEverything.md) works only under Windows and requires [PSEverything](https://www.powershellgallery.com/packages/PSEverything) to be previously installed.
+* [`Set-LocationFuzzyEverything`](docs/Set-LocationFuzzyEverything.md) works only under Windows and requires [PSEverything](https://github.com/powercode/PSEverything) to be previously installed.
 * [`Invoke-FuzzyScoop`](docs/Invoke-FuzzyScoop.md) works only under Windows and requires [Scoop](https://scoop.sh) to be previously installed.
 * [`Invoke-FuzzyGitStatus`](docs/Invoke-FuzzyGitStatus.md) requires [git](https://git-scm.com/) to be installed.
 * [`Invoke-PsFzfRipgrep`](docs/Invoke-PsFzfRipgrep.md) requires [ripgrep](https://github.com/BurntSushi/ripgrep) and [bat](https://github.com/sharkdp/bat) to be installed.


### PR DESCRIPTION
Change PSEverything URL to point to the PSEverything repository, to be consistent with the other links.