### PR TITLE
Fix for issue #219, removing duplicate history items before searching

### DIFF
--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -170,17 +170,19 @@ function Invoke-FuzzyFasd() {
 #.ExternalHelp PSFzf.psm1-help.xml
 function Invoke-FuzzyHistory() {
     if (Get-Command Get-PSReadLineOption -ErrorAction Ignore) {
-        $result = Get-Content (Get-PSReadLineOption).HistorySavePath | Invoke-Fzf -Reverse -Scheme history
+        $history = Get-Content (Get-PSReadLineOption).HistorySavePath
     }
     else {
-        $result = Get-History | ForEach-Object { $_.CommandLine } | Invoke-Fzf -Reverse -Scheme history
+        $history = Get-History | ForEach-Object { $_.CommandLine }
     }
+
+    $result = $history | Sort-Object -Unique | Invoke-Fzf -Reverse -NoSort -Scheme history
+
     if ($null -ne $result) {
         Write-Output "Invoking '$result'`n"
         Invoke-Expression "$result" -Verbose
     }
 }
-
 
 # needs to match helpers/GetProcessesList.ps1
 function GetProcessesList() {


### PR DESCRIPTION
Fix for issue #219. When there is many same entries in history file (example would be dir, git checkout master, etc.) searching would yield many same entries.