### PR TITLE
Fix being unable to override walker opts when not using "fd"

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -631,7 +631,7 @@ function Invoke-FzfDefaultSystem {
 	if ($script:UseFd -and $script:RunningInWindowsTerminal -and -not $script:OverrideFzfDefaultOpts.Get().Contains('--ansi')) {
 		$arguments += "--ansi "
 	}
-	if ($script:UseWalker) {
+	if ($script:UseWalker -and -not $script:OverrideFzfDefaultOpts.Get().Contains('--walker')) {
 		$arguments += "--walker=file,dir "
 	}
 


### PR DESCRIPTION
This PR fixes `--walker` options specified in either `_PSFZF_FZF_DEFAULT_OPTS` or `FZF_DEFAULT_OPTS` being overridden with `--walker=file,dir` defined in `Invoke-FzfDefaultSystem` function.