### PR TITLE
Fix `Invoke-PsFzfRipgrep` throws `unknown action: change-prompt` after updating to 2.6.1 #273

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -387,8 +387,6 @@ function Invoke-Fzf {
 		if ($PSBoundParameters.ContainsKey('PrintQuery') -and $PrintQuery)										{ $arguments += '--print-query '}
 		if ($PSBoundParameters.ContainsKey('Expect') -and ![string]::IsNullOrWhiteSpace($Expect)) 	   			{ $arguments += "--expect=""$Expect"" "}
 
-		#$arguments | Out-File C:\github\crap.txt
-		$Bind | Out-File c:\github\crap.txt -Append
 		if (!$script:OverrideFzfDefaults) {
 			$script:OverrideFzfDefaults = [FzfDefaultOpts]::new("")
 		}

--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -224,7 +224,7 @@ function Set-PsFzfOption{
 	if ($EnableAliasFuzzySetLocation) 	{ SetPsFzfAlias "fd"      Invoke-FuzzySetLocation }
 	if ($EnableAliasFuzzyZLocation) 	{ SetPsFzfAlias "fz"      Invoke-FuzzyZLocation }
 	if ($EnableAliasFuzzyGitStatus) 	{ SetPsFzfAlias "fgs"     Invoke-FuzzyGitStatus }
-	if ($EnableAliasFuzzyScoop) 	{ SetPsFzfAlias "fs"     Invoke-FuzzyScoop }
+	if ($EnableAliasFuzzyScoop) 		{ SetPsFzfAlias "fs"      Invoke-FuzzyScoop }
 	if ($EnableAliasFuzzySetEverything) {
         if (${function:Set-LocationFuzzyEverything}) {
             SetPsFzfAlias "cde" Set-LocationFuzzyEverything
@@ -277,6 +277,7 @@ function Invoke-Fzf {
 		  	[ValidateSet('length','begin','end','index')]
 		  	[string]
 		  	$Tiebreak = $null,
+			[switch]$Disabled,
 
             # Interface
 			[Alias('m')]
@@ -350,6 +351,7 @@ function Invoke-Fzf {
 		if ($PSBoundParameters.ContainsKey('ReverseInput') -and $ReverseInput) 									{ $arguments += '--tac '}
 		if ($PSBoundParameters.ContainsKey('Phony') -and $Phony)												{ $arguments += '--phony '}
 		if ($PSBoundParameters.ContainsKey('Tiebreak') -and ![string]::IsNullOrWhiteSpace($Tiebreak))			{ $arguments += "--tiebreak=$Tiebreak "}
+		if ($PSBoundParameters.ContainsKey('Disabled') -and $Disabled) 											{ $arguments += '--disabled '}
 		if ($PSBoundParameters.ContainsKey('Multi') -and $Multi) 												{ $arguments += '--multi '}
 		if ($PSBoundParameters.ContainsKey('NoMouse') -and $NoMouse)					 						{ $arguments += '--no-mouse '}
         if ($PSBoundParameters.ContainsKey('Bind') -and $Bind.Length -ge 1)							    		{ $Bind | ForEach-Object { $arguments += "--bind=""$_"" " } }
@@ -385,6 +387,8 @@ function Invoke-Fzf {
 		if ($PSBoundParameters.ContainsKey('PrintQuery') -and $PrintQuery)										{ $arguments += '--print-query '}
 		if ($PSBoundParameters.ContainsKey('Expect') -and ![string]::IsNullOrWhiteSpace($Expect)) 	   			{ $arguments += "--expect=""$Expect"" "}
 
+		#$arguments | Out-File C:\github\crap.txt
+		$Bind | Out-File c:\github\crap.txt -Append
 		if (!$script:OverrideFzfDefaults) {
 			$script:OverrideFzfDefaults = [FzfDefaultOpts]::new("")
 		}

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -353,10 +353,8 @@ function Invoke-PsFzfRipgrep() {
         $Bind += 'ctrl-f:unbind(change,ctrl-f)+change-prompt(fzf> )+enable-search+clear-query+rebind(ctrl-r)'
         $Bind += "change:reload:$sleepCmd $RG_PREFIX {q} || $trueCmd"
 
-            $fzfArguments | Out-File C:\github\crap.txt
+        Invoke-Fzf @fzfArguments -Bind $Bind | ForEach-Object { $results += $_ }
 
-            Invoke-Fzf @fzfArguments -Bind $Bind | `
-            ForEach-Object { $results += $_ }
         # we need this here to prevent the editor launch from inherting FZF_DEFAULT_COMMAND from being overwritten (see #267):
         if ($script:OverrideFzfDefaultCommand) {
             $script:OverrideFzfDefaultCommand.Restore()

--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -336,18 +336,26 @@ function Invoke-PsFzfRipgrep() {
             $trueCmd = 'true'
             $env:FZF_DEFAULT_COMMAND = '{0} $(printf %q "{1}")' -f $RG_PREFIX, $INITIAL_QUERY
         }
+        $fzfArguments = @{
+            Ansi = $true
+            Disabled = $true
+            Color = "hl:-1:underline,hl+:-1:underline:reverse"
+            Query = $INITIAL_QUERY
+            Prompt = 'ripgrep> '
+            Delimiter = ':'
+            Header = '? CTRL-R (Ripgrep mode) ? CTRL -F (fzf mode) ?'
+            Preview = 'bat --color=always {1} --highlight-line {2}'
+            PreviewWindow = 'up,60%,border-bottom,+{2}+3/3,~3'
+        }
+        $Bind = @(
+                'ctrl-r:unbind(change,ctrl-r)+change-prompt(ripgrep> )' + "+disable-search+reload($RG_PREFIX {q} || $trueCmd)+rebind(change,ctrl-f)"
+        )
+        $Bind += 'ctrl-f:unbind(change,ctrl-f)+change-prompt(fzf> )+enable-search+clear-query+rebind(ctrl-r)'
+        $Bind += "change:reload:$sleepCmd $RG_PREFIX {q} || $trueCmd"
 
-        & $script:FzfLocation --ansi `
-            --color "hl:-1:underline,hl+:-1:underline:reverse" `
-            --disabled --query "$INITIAL_QUERY" `
-            --bind "change:reload:$sleepCmd $RG_PREFIX {q} || $trueCmd" `
-            --bind "ctrl-f:unbind(change,ctrl-f)+change-prompt" + '( +✅ fzf> )' + "+enable-search+clear-query+rebind(ctrl-r)" `
-            --bind "ctrl-r:unbind(ctrl-r)+change-prompt" + '(🔎 ripgrep> )' + "+disable-search+reload($RG_PREFIX {q} || $trueCmd)+rebind(change,ctrl-f)" `
-            --prompt '🔎 ripgrep> ' `
-            --delimiter : `
-            --header '╱ CTRL-R (Ripgrep mode) ╱ CTRL-F (fzf mode) ╱' `
-            --preview 'bat --color=always {1} --highlight-line {2}' `
-            --preview-window 'up,60%,border-bottom,+{2}+3/3,~3' | `
+            $fzfArguments | Out-File C:\github\crap.txt
+
+            Invoke-Fzf @fzfArguments -Bind $Bind | `
             ForEach-Object { $results += $_ }
         # we need this here to prevent the editor launch from inherting FZF_DEFAULT_COMMAND from being overwritten (see #267):
         if ($script:OverrideFzfDefaultCommand) {


### PR DESCRIPTION
- Resolves #273 
- Add 'Disabled' param
- Restore unicode icons for git functions and only show in Terminal or non-Windows
- Minor formatting fix