### PR TITLE
change of bat highlight language from markdown to man for command help

### DIFF
--- a/helpers/PsFzfTabExpansion-Parameter.ps1
+++ b/helpers/PsFzfTabExpansion-Parameter.ps1
@@ -18,7 +18,7 @@ if ([System.Management.Automation.Cmdlet]::CommonParameters.Contains($parameter)
 }
 else {
     if ($ansiCompatible -and $(Get-Command bat -ErrorAction Ignore)) {
-        Get-Help -Name $Command -Parameter $parameter | bat --language=markdown --color always --style=plain
+        Get-Help -Name $Command -Parameter $parameter | bat --language=man --color always --style=plain
     }
     else {
         Get-Help -Name $Command -Parameter $parameter

--- a/helpers/PsFzfTabExpansion-Preview.ps1
+++ b/helpers/PsFzfTabExpansion-Preview.ps1
@@ -46,7 +46,7 @@ elseif (($cmdResults = Get-Command $Item -ErrorAction Ignore)) {
     if ($cmdResults) {
         if ($cmdResults.CommandType -ne 'Application') {
             if ($ansiCompatible -and $(Get-Command bat -ErrorAction Ignore)) {
-                Get-Help $Item | bat --language=markdown --color always --style=plain
+                Get-Help $Item | bat --language=man --color always --style=plain
             }
             else {
 


### PR DESCRIPTION
I noticed that the highlighting (of bat) in the preview when using the tab expansion on commands and command's parameters was wrong.
So I changed it from `markdown` to `man`