### PR TITLE
fix: revert RunningInWindowsTerminal typo error

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -1010,7 +1010,7 @@ try
 	$script:UseHeightOption = $fzfVersion.length -ge 2 -and `
 							  ([int]$fzfVersion[0] -gt 0 -or `
 							  [int]$fzfVersion[1] -ge 21) -and `
-							  $script:RunningInWindowsTerminald
+							  $script:RunningInWindowsTerminal
 	$script:UseWalker = $fzfVersion.length -ge 2 -and `
 						([int]$fzfVersion[0] -gt 0 -or `
 						[int]$fzfVersion[1] -ge 48)


### PR DESCRIPTION
see issue https://github.com/kelleyma49/PSFzf/issues/297
