### PR TITLE
Fix #297

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -1,8 +1,8 @@
 param(
-	[parameter(Position=0,Mandatory=$false)][string]$PSReadlineChordProvider = 'Ctrl+t',
-	[parameter(Position=1,Mandatory=$false)][string]$PSReadlineChordReverseHistory = 'Ctrl+r',
-	[parameter(Position=2,Mandatory=$false)][string]$PSReadlineChordSetLocation = 'Alt+c',
-	[parameter(Position=3,Mandatory=$false)][string]$PSReadlineChordReverseHistoryArgs = 'Alt+a')
+	[parameter(Position = 0, Mandatory = $false)][string]$PSReadlineChordProvider = 'Ctrl+t',
+	[parameter(Position = 1, Mandatory = $false)][string]$PSReadlineChordReverseHistory = 'Ctrl+r',
+	[parameter(Position = 2, Mandatory = $false)][string]$PSReadlineChordSetLocation = 'Alt+c',
+	[parameter(Position = 3, Mandatory = $false)][string]$PSReadlineChordReverseHistoryArgs = 'Alt+a')
 
 $script:IsWindows = ($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows
 if ($script:IsWindows) {
@@ -13,7 +13,8 @@ dir /s/b "{0}"
 	$script:DefaultFileSystemCmdDirOnly = @"
 dir /s/b/ad "{0}"
 "@
-} else {
+}
+else {
 	$script:ShellCmd = '/bin/sh -c "{0}"'
 	$script:DefaultFileSystemCmd = @"
 find -L '{0}' -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null
@@ -23,15 +24,16 @@ find -L '{0}' -path '*/\.*' -prune -o -type d -print 2> /dev/null
 "@
 }
 
-$script:RunningInWindowsTerminal = [bool]($env:WT_Session) -or [bool]($env:ConEmuANSI)
-if ($script:RunningInWindowsTerminal) {
+$script:AnsiCompatible = [bool]($env:WT_Session) -or [bool]($env:ConEmuANSI) -or (-not $IsWindows)
+if ($script:AnsiCompatible) {
 	$script:DefaultFileSystemFdCmd = "fd.exe --color always . --full-path `"{0}`" --fixed-strings"
-} else {
+}
+else {
 	$script:DefaultFileSystemFdCmd = "fd.exe . --full-path `"{0}`" --fixed-strings"
 }
 
 $script:UseFd = $false
-$script:AltCCommand = [ScriptBlock]{
+$script:AltCCommand = [ScriptBlock] {
 	param($Location)
 	Set-Location $Location
 }
@@ -45,17 +47,20 @@ function Get-FileSystemCmd {
 		if ($script:UseFd) {
 			if ($dirOnly) {
 				"$($script:DefaultFileSystemFdCmd -f $dir) --type directory"
-			} else {
+			}
+			else {
 				$script:DefaultFileSystemFdCmd -f $dir
 			}
-		} else {
+		}
+		else {
 			$cmd = $script:DefaultFileSystemCmd
 			if ($dirOnly) {
 				$cmd = $script:DefaultFileSystemCmdDirOnly
 			}
 			$script:ShellCmd -f ($cmd -f $dir)
 		}
-	} else {
+	}
+ else {
 		$script:ShellCmd -f ($env:FZF_DEFAULT_COMMAND -f $dir)
 	}
 }
@@ -74,7 +79,8 @@ class FzfDefaultOpts {
 	[string]Get() {
 		if ($this.UsePsFzfOpts) {
 			return $env:_PSFZF_FZF_DEFAULT_OPTS;
-		} else {
+		}
+		else {
 			return $env:FZF_DEFAULT_OPTS;
 		}
 	}
@@ -97,23 +103,24 @@ class FzfDefaultCmd {
 	}
 }
 
-function FixCompletionResult($str)
-{
+function FixCompletionResult($str) {
 	if ([string]::IsNullOrEmpty($str)) {
 		return ""
 	}
 	elseif ($str.Contains(" ") -or $str.Contains("`t")) {
-		$str = $str.Replace("`r`n","")
+		$str = $str.Replace("`r`n", "")
 		# check if already quoted
 		if (($str.StartsWith("'") -and $str.EndsWith("'")) -or `
 			($str.StartsWith("""") -and $str.EndsWith(""""))) {
-				return $str
-			} else {
-				return """{0}""" -f $str
-			}
+			return $str
+		}
+		else {
+			return """{0}""" -f $str
+		}
 
-	} else {
-		return $str.Replace("`r`n","")
+	}
+ else {
+		return $str.Replace("`r`n", "")
 	}
 }
 
@@ -122,14 +129,14 @@ function FixCompletionResult($str)
 #HACK: workaround for fact that PSReadLine seems to clear screen
 # after keyboard shortcut action is executed, and to work around a UTF8
 # PSReadLine issue (GitHub PSFZF issue #71)
-function InvokePromptHack()
-{
+function InvokePromptHack() {
 	$previousOutputEncoding = [Console]::OutputEncoding
 	[Console]::OutputEncoding = [Text.Encoding]::UTF8
 
 	try {
 		[Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
-	} finally {
+	}
+ finally {
 		[Console]::OutputEncoding = $previousOutputEncoding
 	}
 }
@@ -153,12 +160,13 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove =
 function script:PrepareArg($argStr) {
 	if (-not $argStr.EndsWith("\\") -and $argStr.EndsWith('\')) {
 		return $argStr + '\'
-	} else {
+	}
+ else {
 		return $argStr
 	}
 }
 
-function Set-PsFzfOption{
+function Set-PsFzfOption {
 	param(
 		[switch]
 		$TabExpansion,
@@ -219,18 +227,18 @@ function Set-PsFzfOption{
 		}
 	}
 
-	if ($EnableAliasFuzzyEdit) 			{ SetPsFzfAlias "fe"      Invoke-FuzzyEdit}
-	if ($EnableAliasFuzzyFasd) 			{ SetPsFzfAlias "ff"      Invoke-FuzzyFasd}
-	if ($EnableAliasFuzzyHistory) 		{ SetPsFzfAlias "fh"      Invoke-FuzzyHistory }
-	if ($EnableAliasFuzzyKillProcess) 	{ SetPsFzfAlias "fkill"   Invoke-FuzzyKillProcess }
-	if ($EnableAliasFuzzySetLocation) 	{ SetPsFzfAlias "fd"      Invoke-FuzzySetLocation }
-	if ($EnableAliasFuzzyZLocation) 	{ SetPsFzfAlias "fz"      Invoke-FuzzyZLocation }
-	if ($EnableAliasFuzzyGitStatus) 	{ SetPsFzfAlias "fgs"     Invoke-FuzzyGitStatus }
-	if ($EnableAliasFuzzyScoop) 		{ SetPsFzfAlias "fs"      Invoke-FuzzyScoop }
+	if ($EnableAliasFuzzyEdit) { SetPsFzfAlias "fe"      Invoke-FuzzyEdit }
+	if ($EnableAliasFuzzyFasd) { SetPsFzfAlias "ff"      Invoke-FuzzyFasd }
+	if ($EnableAliasFuzzyHistory) { SetPsFzfAlias "fh"      Invoke-FuzzyHistory }
+	if ($EnableAliasFuzzyKillProcess) { SetPsFzfAlias "fkill"   Invoke-FuzzyKillProcess }
+	if ($EnableAliasFuzzySetLocation) { SetPsFzfAlias "fd"      Invoke-FuzzySetLocation }
+	if ($EnableAliasFuzzyZLocation) { SetPsFzfAlias "fz"      Invoke-FuzzyZLocation }
+	if ($EnableAliasFuzzyGitStatus) { SetPsFzfAlias "fgs"     Invoke-FuzzyGitStatus }
+	if ($EnableAliasFuzzyScoop) { SetPsFzfAlias "fs"      Invoke-FuzzyScoop }
 	if ($EnableAliasFuzzySetEverything) {
-        if (${function:Set-LocationFuzzyEverything}) {
-            SetPsFzfAlias "cde" Set-LocationFuzzyEverything
-        }
+		if (${function:Set-LocationFuzzyEverything}) {
+			SetPsFzfAlias "cde" Set-LocationFuzzyEverything
+		}
 	}
 	if ($PSBoundParameters.ContainsKey('EnableFd')) {
 		$script:UseFd = $EnableFd
@@ -259,187 +267,187 @@ function Stop-Pipeline {
 
 function Invoke-Fzf {
 	param(
-            # Search
-			[Alias("x")]
-			[switch]$Extended,
-			[Alias('e')]
-		  	[switch]$Exact,
-			[Alias('i')]
-		  	[switch]$CaseInsensitive,
-		  	[switch]$CaseSensitive,
-			[ValidateSet('default','path','history')]
-		  	[string]
-		  	$Scheme = $null,
-		  	[Alias('d')]
-		  	[string]$Delimiter,
-		  	[switch]$NoSort,
-			[Alias('tac')]
-			[switch]$ReverseInput,
-			[switch]$Phony,
-		  	[ValidateSet('length','begin','end','index')]
-		  	[string]
-		  	$Tiebreak = $null,
-			[switch]$Disabled,
+		# Search
+		[Alias("x")]
+		[switch]$Extended,
+		[Alias('e')]
+		[switch]$Exact,
+		[Alias('i')]
+		[switch]$CaseInsensitive,
+		[switch]$CaseSensitive,
+		[ValidateSet('default', 'path', 'history')]
+		[string]
+		$Scheme = $null,
+		[Alias('d')]
+		[string]$Delimiter,
+		[switch]$NoSort,
+		[Alias('tac')]
+		[switch]$ReverseInput,
+		[switch]$Phony,
+		[ValidateSet('length', 'begin', 'end', 'index')]
+		[string]
+		$Tiebreak = $null,
+		[switch]$Disabled,
 
-            # Interface
-			[Alias('m')]
-		  	[switch]$Multi,
-			[switch]$NoMouse,
-            [string[]]$Bind,
-			[switch]$Cycle,
-			[switch]$KeepRight,
-			[switch]$NoHScroll,
-			[switch]$FilepathWord,
+		# Interface
+		[Alias('m')]
+		[switch]$Multi,
+		[switch]$NoMouse,
+		[string[]]$Bind,
+		[switch]$Cycle,
+		[switch]$KeepRight,
+		[switch]$NoHScroll,
+		[switch]$FilepathWord,
 
-			# Layout
-			[ValidatePattern("^[1-9]+[0-9]+$|^[1-9][0-9]?%?$|^100%?$")]
-			[string]$Height,
-			[ValidateRange(1,[int]::MaxValue)]
-			[int]$MinHeight,
-			[ValidateSet('default','reverse','reverse-list')]
-			[string]$Layout = $null,
-			[switch]$Border,
-			[ValidateSet('rounded', 'sharp', 'bold', 'block', 'double', 'horizontal', 'vertical', 'top', 'bottom', 'left', 'right', 'none')]
-			[string]$BorderStyle,
-			[string]$BorderLabel,
-			[ValidateSet('default','inline','hidden')]
-			[string]$Info = $null,
-			[string]$Prompt,
-			[string]$Pointer,
-			[string]$Marker,
-			[string]$Header,
-			[int]$HeaderLines = -1,
+		# Layout
+		[ValidatePattern("^[1-9]+[0-9]+$|^[1-9][0-9]?%?$|^100%?$")]
+		[string]$Height,
+		[ValidateRange(1, [int]::MaxValue)]
+		[int]$MinHeight,
+		[ValidateSet('default', 'reverse', 'reverse-list')]
+		[string]$Layout = $null,
+		[switch]$Border,
+		[ValidateSet('rounded', 'sharp', 'bold', 'block', 'double', 'horizontal', 'vertical', 'top', 'bottom', 'left', 'right', 'none')]
+		[string]$BorderStyle,
+		[string]$BorderLabel,
+		[ValidateSet('default', 'inline', 'hidden')]
+		[string]$Info = $null,
+		[string]$Prompt,
+		[string]$Pointer,
+		[string]$Marker,
+		[string]$Header,
+		[int]$HeaderLines = -1,
 
-			# Display
-			[switch]$Ansi,
-			[int]$Tabstop = 8,
-			[string]$Color,
-			[switch]$NoBold,
+		# Display
+		[switch]$Ansi,
+		[int]$Tabstop = 8,
+		[string]$Color,
+		[switch]$NoBold,
 
-            # History
-			[string]$History,
-			[int]$HistorySize = -1,
+		# History
+		[string]$History,
+		[int]$HistorySize = -1,
 
-            #Preview
-            [string]$Preview,
-			[string]$PreviewWindow,
+		#Preview
+		[string]$Preview,
+		[string]$PreviewWindow,
 
-            # Scripting
-			[Alias('q')]
-			[string]$Query,
-			[Alias('s1')]
-			[switch]$Select1,
-			[Alias('e0')]
-			[switch]$Exit0,
-			[Alias('f')]
-			[string]$Filter,
-			[switch]$PrintQuery,
-			[string]$Expect,
+		# Scripting
+		[Alias('q')]
+		[string]$Query,
+		[Alias('s1')]
+		[switch]$Select1,
+		[Alias('e0')]
+		[switch]$Exit0,
+		[Alias('f')]
+		[string]$Filter,
+		[switch]$PrintQuery,
+		[string]$Expect,
 
-		  	[Parameter(ValueFromPipeline=$True)]
-            [object[]]$Input
-    )
+		[Parameter(ValueFromPipeline = $True)]
+		[object[]]$Input
+	)
 
 	Begin {
 		# process parameters:
 		$arguments = ''
-		if ($PSBoundParameters.ContainsKey('Extended') -and $Extended) 											{ $arguments += '--extended '}
-		if ($PSBoundParameters.ContainsKey('Exact') -and $Exact) 			        							{ $arguments += '--exact '}
-		if ($PSBoundParameters.ContainsKey('CaseInsensitive') -and $CaseInsensitive) 							{ $arguments += '-i '}
-		if ($PSBoundParameters.ContainsKey('CaseSensitive') -and $CaseSensitive) 								{ $arguments += '+i '}
-		if ($PSBoundParameters.ContainsKey('Scheme') -and ![string]::IsNullOrWhiteSpace($Scheme)) 				{ $arguments += "--scheme=$Scheme "}
-		if ($PSBoundParameters.ContainsKey('Delimiter') -and ![string]::IsNullOrWhiteSpace($Delimiter)) 		{ $arguments += "--delimiter=$Delimiter "}
-		if ($PSBoundParameters.ContainsKey('NoSort') -and $NoSort) 												{ $arguments += '--no-sort '}
-		if ($PSBoundParameters.ContainsKey('ReverseInput') -and $ReverseInput) 									{ $arguments += '--tac '}
-		if ($PSBoundParameters.ContainsKey('Phony') -and $Phony)												{ $arguments += '--phony '}
-		if ($PSBoundParameters.ContainsKey('Tiebreak') -and ![string]::IsNullOrWhiteSpace($Tiebreak))			{ $arguments += "--tiebreak=$Tiebreak "}
-		if ($PSBoundParameters.ContainsKey('Disabled') -and $Disabled) 											{ $arguments += '--disabled '}
-		if ($PSBoundParameters.ContainsKey('Multi') -and $Multi) 												{ $arguments += '--multi '}
-		if ($PSBoundParameters.ContainsKey('NoMouse') -and $NoMouse)					 						{ $arguments += '--no-mouse '}
-        if ($PSBoundParameters.ContainsKey('Bind') -and $Bind.Length -ge 1)							    		{ $Bind | ForEach-Object { $arguments += "--bind=""$_"" " } }
-		if ($PSBoundParameters.ContainsKey('Reverse') -and $Reverse)					 						{ $arguments += '--reverse '}
-		if ($PSBoundParameters.ContainsKey('Cycle') -and $Cycle)						 						{ $arguments += '--cycle '}
-		if ($PSBoundParameters.ContainsKey('KeepRight') -and $KeepRight)						 				{ $arguments += '--keep-right '}
-		if ($PSBoundParameters.ContainsKey('NoHScroll') -and $NoHScroll) 										{ $arguments += '--no-hscroll '}
-		if ($PSBoundParameters.ContainsKey('FilepathWord') -and $FilepathWord)									{ $arguments += '--filepath-word '}
-		if ($PSBoundParameters.ContainsKey('Height') -and ![string]::IsNullOrWhiteSpace($Height))				{ $arguments += "--height=$height "}
-		if ($PSBoundParameters.ContainsKey('MinHeight') -and $MinHeight -ge 0)									{ $arguments += "--min-height=$MinHeight "}
-		if ($PSBoundParameters.ContainsKey('Layout') -and ![string]::IsNullOrWhiteSpace($Layout))				{ $arguments += "--layout=$Layout "}
-		if ($PSBoundParameters.ContainsKey('Border') -and $Border)												{ $arguments += '--border '}
-		if ($PSBoundParameters.ContainsKey('BorderLabel') -and ![string]::IsNullOrWhiteSpace($BorderLabel))		{ $arguments += "--border-label=""$BorderLabel"" "}
-		if ($PSBoundParameters.ContainsKey('BorderStyle') -and ![string]::IsNullOrWhiteSpace($BorderStyle))		{ $arguments += "--border=$BorderStyle "}
-		if ($PSBoundParameters.ContainsKey('Info') -and ![string]::IsNullOrWhiteSpace($Info)) 					{ $arguments += "--info=$Info "}
-		if ($PSBoundParameters.ContainsKey('Prompt') -and ![string]::IsNullOrWhiteSpace($Prompt)) 				{ $arguments += "--prompt=""$Prompt"" "}
-		if ($PSBoundParameters.ContainsKey('Pointer') -and ![string]::IsNullOrWhiteSpace($Pointer)) 			{ $arguments += "--pointer=""$Pointer"" "}
-		if ($PSBoundParameters.ContainsKey('Marker') -and ![string]::IsNullOrWhiteSpace($Marker)) 				{ $arguments += "--marker=""$Marker"" "}
-        if ($PSBoundParameters.ContainsKey('Header') -and ![string]::IsNullOrWhiteSpace($Header)) 				{ $arguments += "--header=""$Header"" "}
-		if ($PSBoundParameters.ContainsKey('HeaderLines') -and $HeaderLines -ge 0) 		               			{ $arguments += "--header-lines=$HeaderLines "}
-		if ($PSBoundParameters.ContainsKey('Ansi') -and $Ansi)													{ $arguments += '--ansi '}
-		if ($PSBoundParameters.ContainsKey('Tabstop') -and $Tabstop -ge 0)										{ $arguments += "--tabstop=$Tabstop "}
-		if ($PSBoundParameters.ContainsKey('Color') -and ![string]::IsNullOrWhiteSpace($Color))	 				{ $arguments += "--color=""$Color"" "}
-		if ($PSBoundParameters.ContainsKey('NoBold') -and $NoBold)												{ $arguments += '--no-bold '}
-		if ($PSBoundParameters.ContainsKey('History') -and $History) 											{ $arguments += "--history=""$History"" "}
-		if ($PSBoundParameters.ContainsKey('HistorySize') -and $HistorySize -ge 1)								{ $arguments += "--history-size=$HistorySize "}
-        if ($PSBoundParameters.ContainsKey('Preview') -and ![string]::IsNullOrWhiteSpace($Preview)) 	    	{ $arguments += "--preview=""$Preview"" "}
-        if ($PSBoundParameters.ContainsKey('PreviewWindow') -and ![string]::IsNullOrWhiteSpace($PreviewWindow)) { $arguments += "--preview-window=""$PreviewWindow"" "}
-		if ($PSBoundParameters.ContainsKey('Query') -and ![string]::IsNullOrWhiteSpace($Query))					{ $arguments += "--query=""{0}"" " -f $(PrepareArg $Query)}
-		if ($PSBoundParameters.ContainsKey('Select1') -and $Select1)											{ $arguments += '--select-1 '}
-		if ($PSBoundParameters.ContainsKey('Exit0') -and $Exit0)												{ $arguments += '--exit-0 '}
-		if ($PSBoundParameters.ContainsKey('Filter') -and ![string]::IsNullOrEmpty($Filter))					{ $arguments += "--filter=$Filter " }
-		if ($PSBoundParameters.ContainsKey('PrintQuery') -and $PrintQuery)										{ $arguments += '--print-query '}
-		if ($PSBoundParameters.ContainsKey('Expect') -and ![string]::IsNullOrWhiteSpace($Expect)) 	   			{ $arguments += "--expect=""$Expect"" "}
+		if ($PSBoundParameters.ContainsKey('Extended') -and $Extended) { $arguments += '--extended ' }
+		if ($PSBoundParameters.ContainsKey('Exact') -and $Exact) { $arguments += '--exact ' }
+		if ($PSBoundParameters.ContainsKey('CaseInsensitive') -and $CaseInsensitive) { $arguments += '-i ' }
+		if ($PSBoundParameters.ContainsKey('CaseSensitive') -and $CaseSensitive) { $arguments += '+i ' }
+		if ($PSBoundParameters.ContainsKey('Scheme') -and ![string]::IsNullOrWhiteSpace($Scheme)) { $arguments += "--scheme=$Scheme " }
+		if ($PSBoundParameters.ContainsKey('Delimiter') -and ![string]::IsNullOrWhiteSpace($Delimiter)) { $arguments += "--delimiter=$Delimiter " }
+		if ($PSBoundParameters.ContainsKey('NoSort') -and $NoSort) { $arguments += '--no-sort ' }
+		if ($PSBoundParameters.ContainsKey('ReverseInput') -and $ReverseInput) { $arguments += '--tac ' }
+		if ($PSBoundParameters.ContainsKey('Phony') -and $Phony) { $arguments += '--phony ' }
+		if ($PSBoundParameters.ContainsKey('Tiebreak') -and ![string]::IsNullOrWhiteSpace($Tiebreak)) { $arguments += "--tiebreak=$Tiebreak " }
+		if ($PSBoundParameters.ContainsKey('Disabled') -and $Disabled) { $arguments += '--disabled ' }
+		if ($PSBoundParameters.ContainsKey('Multi') -and $Multi) { $arguments += '--multi ' }
+		if ($PSBoundParameters.ContainsKey('NoMouse') -and $NoMouse) { $arguments += '--no-mouse ' }
+		if ($PSBoundParameters.ContainsKey('Bind') -and $Bind.Length -ge 1) { $Bind | ForEach-Object { $arguments += "--bind=""$_"" " } }
+		if ($PSBoundParameters.ContainsKey('Reverse') -and $Reverse) { $arguments += '--reverse ' }
+		if ($PSBoundParameters.ContainsKey('Cycle') -and $Cycle) { $arguments += '--cycle ' }
+		if ($PSBoundParameters.ContainsKey('KeepRight') -and $KeepRight) { $arguments += '--keep-right ' }
+		if ($PSBoundParameters.ContainsKey('NoHScroll') -and $NoHScroll) { $arguments += '--no-hscroll ' }
+		if ($PSBoundParameters.ContainsKey('FilepathWord') -and $FilepathWord) { $arguments += '--filepath-word ' }
+		if ($PSBoundParameters.ContainsKey('Height') -and ![string]::IsNullOrWhiteSpace($Height)) { $arguments += "--height=$height " }
+		if ($PSBoundParameters.ContainsKey('MinHeight') -and $MinHeight -ge 0) { $arguments += "--min-height=$MinHeight " }
+		if ($PSBoundParameters.ContainsKey('Layout') -and ![string]::IsNullOrWhiteSpace($Layout)) { $arguments += "--layout=$Layout " }
+		if ($PSBoundParameters.ContainsKey('Border') -and $Border) { $arguments += '--border ' }
+		if ($PSBoundParameters.ContainsKey('BorderLabel') -and ![string]::IsNullOrWhiteSpace($BorderLabel)) { $arguments += "--border-label=""$BorderLabel"" " }
+		if ($PSBoundParameters.ContainsKey('BorderStyle') -and ![string]::IsNullOrWhiteSpace($BorderStyle)) { $arguments += "--border=$BorderStyle " }
+		if ($PSBoundParameters.ContainsKey('Info') -and ![string]::IsNullOrWhiteSpace($Info)) { $arguments += "--info=$Info " }
+		if ($PSBoundParameters.ContainsKey('Prompt') -and ![string]::IsNullOrWhiteSpace($Prompt)) { $arguments += "--prompt=""$Prompt"" " }
+		if ($PSBoundParameters.ContainsKey('Pointer') -and ![string]::IsNullOrWhiteSpace($Pointer)) { $arguments += "--pointer=""$Pointer"" " }
+		if ($PSBoundParameters.ContainsKey('Marker') -and ![string]::IsNullOrWhiteSpace($Marker)) { $arguments += "--marker=""$Marker"" " }
+		if ($PSBoundParameters.ContainsKey('Header') -and ![string]::IsNullOrWhiteSpace($Header)) { $arguments += "--header=""$Header"" " }
+		if ($PSBoundParameters.ContainsKey('HeaderLines') -and $HeaderLines -ge 0) { $arguments += "--header-lines=$HeaderLines " }
+		if ($PSBoundParameters.ContainsKey('Ansi') -and $Ansi) { $arguments += '--ansi ' }
+		if ($PSBoundParameters.ContainsKey('Tabstop') -and $Tabstop -ge 0) { $arguments += "--tabstop=$Tabstop " }
+		if ($PSBoundParameters.ContainsKey('Color') -and ![string]::IsNullOrWhiteSpace($Color)) { $arguments += "--color=""$Color"" " }
+		if ($PSBoundParameters.ContainsKey('NoBold') -and $NoBold) { $arguments += '--no-bold ' }
+		if ($PSBoundParameters.ContainsKey('History') -and $History) { $arguments += "--history=""$History"" " }
+		if ($PSBoundParameters.ContainsKey('HistorySize') -and $HistorySize -ge 1) { $arguments += "--history-size=$HistorySize " }
+		if ($PSBoundParameters.ContainsKey('Preview') -and ![string]::IsNullOrWhiteSpace($Preview)) { $arguments += "--preview=""$Preview"" " }
+		if ($PSBoundParameters.ContainsKey('PreviewWindow') -and ![string]::IsNullOrWhiteSpace($PreviewWindow)) { $arguments += "--preview-window=""$PreviewWindow"" " }
+		if ($PSBoundParameters.ContainsKey('Query') -and ![string]::IsNullOrWhiteSpace($Query)) { $arguments += "--query=""{0}"" " -f $(PrepareArg $Query) }
+		if ($PSBoundParameters.ContainsKey('Select1') -and $Select1) { $arguments += '--select-1 ' }
+		if ($PSBoundParameters.ContainsKey('Exit0') -and $Exit0) { $arguments += '--exit-0 ' }
+		if ($PSBoundParameters.ContainsKey('Filter') -and ![string]::IsNullOrEmpty($Filter)) { $arguments += "--filter=$Filter " }
+		if ($PSBoundParameters.ContainsKey('PrintQuery') -and $PrintQuery) { $arguments += '--print-query ' }
+		if ($PSBoundParameters.ContainsKey('Expect') -and ![string]::IsNullOrWhiteSpace($Expect)) { $arguments += "--expect=""$Expect"" " }
 
 		if (!$script:OverrideFzfDefaults) {
 			$script:OverrideFzfDefaults = [FzfDefaultOpts]::new("")
 		}
 
 		if ($script:UseHeightOption -and [string]::IsNullOrWhiteSpace($Height) -and `
-		  	([string]::IsNullOrWhiteSpace($script:OverrideFzfDefaults.Get()) -or `
-			(-not $script:OverrideFzfDefaults.Get().Contains('--height')))) {
+			([string]::IsNullOrWhiteSpace($script:OverrideFzfDefaults.Get()) -or `
+				(-not $script:OverrideFzfDefaults.Get().Contains('--height')))) {
 			$arguments += "--height=40% "
 		}
 
 		if ($Border -eq $true -and -not [string]::IsNullOrWhiteSpace($BorderStyle)) {
 			throw '-Border and -BorderStyle are mutally exclusive'
 		}
-		if ($script:UseFd -and $script:RunningInWindowsTerminal -and -not $arguments.Contains('--ansi')) {
+		if ($script:UseFd -and $script:AnsiCompatible -and -not $arguments.Contains('--ansi')) {
 			$arguments += "--ansi "
 		}
 
 		# prepare to start process:
-        $process = New-Object System.Diagnostics.Process
-        $process.StartInfo.FileName = $script:FzfLocation
+		$process = New-Object System.Diagnostics.Process
+		$process.StartInfo.FileName = $script:FzfLocation
 		$process.StartInfo.Arguments = $arguments
-        $process.StartInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
-        $process.StartInfo.RedirectStandardInput = $true
-        $process.StartInfo.RedirectStandardOutput = $true
+		$process.StartInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+		$process.StartInfo.RedirectStandardInput = $true
+		$process.StartInfo.RedirectStandardOutput = $true
 		$process.StartInfo.UseShellExecute = $false
 		if ($pwd.Provider.Name -eq 'FileSystem') {
 			$process.StartInfo.WorkingDirectory = $pwd.ProviderPath
 		}
 
-        # Adding event handers for stdout:
-    	$stdOutEventId = "PsFzfStdOutEh-" + [System.Guid]::NewGuid()
-    	$stdOutEvent = Register-ObjectEvent -InputObject $process `
-    		-EventName 'OutputDataReceived' `
+		# Adding event handers for stdout:
+		$stdOutEventId = "PsFzfStdOutEh-" + [System.Guid]::NewGuid()
+		$stdOutEvent = Register-ObjectEvent -InputObject $process `
+			-EventName 'OutputDataReceived' `
 			-SourceIdentifier $stdOutEventId
 
-        $processHasExited = new-object psobject -property @{flag = $false}
-        # register on exit:
-        $scriptBlockExited = {
-            $Event.MessageData.flag = $true
-        }
-        $exitedEventId = "PsFzfExitedEh-" + [System.Guid]::NewGuid()
-        $exitedEvent = Register-ObjectEvent -InputObject $process `
-        	-Action $scriptBlockExited -EventName 'Exited' `
+		$processHasExited = new-object psobject -property @{flag = $false }
+		# register on exit:
+		$scriptBlockExited = {
+			$Event.MessageData.flag = $true
+		}
+		$exitedEventId = "PsFzfExitedEh-" + [System.Guid]::NewGuid()
+		$exitedEvent = Register-ObjectEvent -InputObject $process `
+			-Action $scriptBlockExited -EventName 'Exited' `
 			-SourceIdentifier $exitedEventId `
-        	-MessageData $processHasExited
+			-MessageData $processHasExited
 
-        $process.Start() | Out-Null
-        $process.BeginOutputReadLine() | Out-Null
+		$process.Start() | Out-Null
+		$process.BeginOutputReadLine() | Out-Null
 
 		$utf8Encoding = New-Object System.Text.UTF8Encoding -ArgumentList $false
-        $script:utf8Stream = New-Object System.IO.StreamWriter -ArgumentList $process.StandardInput.BaseStream, $utf8Encoding
+		$script:utf8Stream = New-Object System.IO.StreamWriter -ArgumentList $process.StandardInput.BaseStream, $utf8Encoding
 
 		$cleanup = [scriptblock] {
 			if ($script:OverrideFzfDefaults) {
@@ -448,9 +456,10 @@ function Invoke-Fzf {
 			}
 
 			try {
-           		$process.StandardInput.Close() | Out-Null
+				$process.StandardInput.Close() | Out-Null
 				$process.WaitForExit()
-			} catch {
+			}
+			catch {
 				# do nothing
 			}
 
@@ -459,11 +468,12 @@ function Invoke-Fzf {
 				#	Unregister-Event $_ -ErrorAction SilentlyContinue
 				#}
 
-				$stdOutEvent,$exitedEvent | ForEach-Object {
+				$stdOutEvent, $exitedEvent | ForEach-Object {
 					Stop-Job $_  -ErrorAction SilentlyContinue
 					Remove-Job $_ -Force  -ErrorAction SilentlyContinue
 				}
-			} catch {
+			}
+			catch {
 
 			}
 
@@ -472,9 +482,9 @@ function Invoke-Fzf {
 			Get-Event -SourceIdentifier $stdOutEventId | `
 				Sort-Object -Property TimeGenerated | `
 				Where-Object { $null -ne $_.SourceEventArgs.Data } | ForEach-Object {
-					Write-Output $_.SourceEventArgs.Data
-					Remove-Event -EventIdentifier $_.EventIdentifier
-				}
+				Write-Output $_.SourceEventArgs.Data
+				Remove-Event -EventIdentifier $_.EventIdentifier
+			}
 		}
 		$checkProcessStatus = [scriptblock] {
 			if ($processHasExited.flag -or $process.HasExited) {
@@ -486,18 +496,20 @@ function Invoke-Fzf {
 	}
 
 	Process {
-        $hasInput = $PSBoundParameters.ContainsKey('Input')
+		$hasInput = $PSBoundParameters.ContainsKey('Input')
 
-        # handle no piped input:
+		# handle no piped input:
 		if (!$hasInput) {
 			# optimization for filesystem provider:
 			if ($PWD.Provider.Name -eq 'FileSystem') {
 				Invoke-Expression (Get-FileSystemCmd $PWD.ProviderPath) | ForEach-Object {
 					try {
 						$utf8Stream.WriteLine($_)
-					} catch [System.Management.Automation.MethodInvocationException] {
+					}
+					catch [System.Management.Automation.MethodInvocationException] {
 						# Possibly broken pipe. Next clause will handle graceful shutdown.
-					} finally {
+					}
+					finally {
 						& $checkProcessStatus
 					}
 				}
@@ -507,7 +519,8 @@ function Invoke-Fzf {
 					$item = $_
 					if ($item -is [System.String]) {
 						$str = $item
-					} else {
+					}
+					else {
 						# search through common properties:
 						$str = $item.FullName
 						if ($null -eq $str) {
@@ -519,18 +532,21 @@ function Invoke-Fzf {
 					}
 					try {
 						$utf8Stream.WriteLine($str)
-					} catch [System.Management.Automation.MethodInvocationException] {
+					}
+					catch [System.Management.Automation.MethodInvocationException] {
 						# Possibly broken pipe. We will shutdown the pipe below.
 					}
 					& $checkProcessStatus
 				}
 			}
 
-		} else {
+		}
+		else {
 			foreach ($item in $Input) {
 				if ($item -is [System.String]) {
 					$str = $item
-				} else {
+				}
+				else {
 					# search through common properties:
 					$str = $item.FullName
 					if ($null -eq $str) {
@@ -542,7 +558,8 @@ function Invoke-Fzf {
 				}
 				try {
 					$utf8Stream.WriteLine($str)
-				} catch [System.Management.Automation.MethodInvocationException] {
+				}
+				catch [System.Management.Automation.MethodInvocationException] {
 					# Possibly broken pipe. We will shutdown the pipe below.
 				}
 				& $checkProcessStatus
@@ -551,7 +568,8 @@ function Invoke-Fzf {
 		if ($null -ne $utf8Stream) {
 			try {
 				$utf8Stream.Flush()
-			} catch [System.Management.Automation.MethodInvocationException] {
+			}
+			catch [System.Management.Automation.MethodInvocationException] {
 				# Possibly broken pipe, check process status.
 				& $checkProcessStatus
 			}
@@ -564,7 +582,7 @@ function Invoke-Fzf {
 }
 
 function Find-CurrentPath {
-	param([string]$line,[int]$cursor,[ref]$leftCursor,[ref]$rightCursor)
+	param([string]$line, [int]$cursor, [ref]$leftCursor, [ref]$rightCursor)
 
 	if ($line.Length -eq 0) {
 		$leftCursor.Value = $rightCursor.Value = 0
@@ -573,23 +591,25 @@ function Find-CurrentPath {
 
 	if ($cursor -ge $line.Length) {
 		$leftCursorTmp = $cursor - 1
-	} else {
+	}
+ else {
 		$leftCursorTmp = $cursor
 	}
-	:leftSearch for (;$leftCursorTmp -ge 0;$leftCursorTmp--) {
+	:leftSearch for (; $leftCursorTmp -ge 0; $leftCursorTmp--) {
 		if ([string]::IsNullOrWhiteSpace($line[$leftCursorTmp])) {
-			if (($leftCursorTmp -lt $cursor) -and ($leftCursorTmp -lt $line.Length-1)) {
+			if (($leftCursorTmp -lt $cursor) -and ($leftCursorTmp -lt $line.Length - 1)) {
 				$leftCursorTmpQuote = $leftCursorTmp - 1
 				$leftCursorTmp = $leftCursorTmp + 1
-			} else {
+			}
+			else {
 				$leftCursorTmpQuote = $leftCursorTmp
 			}
-			for (;$leftCursorTmpQuote -ge 0;$leftCursorTmpQuote--) {
-				if (($line[$leftCursorTmpQuote] -eq '"') -and (($leftCursorTmpQuote -le 0) -or ($line[$leftCursorTmpQuote-1] -ne '"'))) {
+			for (; $leftCursorTmpQuote -ge 0; $leftCursorTmpQuote--) {
+				if (($line[$leftCursorTmpQuote] -eq '"') -and (($leftCursorTmpQuote -le 0) -or ($line[$leftCursorTmpQuote - 1] -ne '"'))) {
 					$leftCursorTmp = $leftCursorTmpQuote
 					break leftSearch
 				}
-				elseif (($line[$leftCursorTmpQuote] -eq "'") -and (($leftCursorTmpQuote -le 0) -or ($line[$leftCursorTmpQuote-1] -ne "'"))) {
+				elseif (($line[$leftCursorTmpQuote] -eq "'") -and (($leftCursorTmpQuote -le 0) -or ($line[$leftCursorTmpQuote - 1] -ne "'"))) {
 					$leftCursorTmp = $leftCursorTmpQuote
 					break leftSearch
 				}
@@ -597,17 +617,17 @@ function Find-CurrentPath {
 			break leftSearch
 		}
 	}
-	:rightSearch for ($rightCursorTmp = $cursor;$rightCursorTmp -lt $line.Length;$rightCursorTmp++) {
+	:rightSearch for ($rightCursorTmp = $cursor; $rightCursorTmp -lt $line.Length; $rightCursorTmp++) {
 		if ([string]::IsNullOrWhiteSpace($line[$rightCursorTmp])) {
 			if ($rightCursorTmp -gt $cursor) {
 				$rightCursorTmp = $rightCursorTmp - 1
 			}
-			for ($rightCursorTmpQuote = $rightCursorTmp+1;$rightCursorTmpQuote -lt $line.Length;$rightCursorTmpQuote++) {
-				if (($line[$rightCursorTmpQuote] -eq '"') -and (($rightCursorTmpQuote -gt $line.Length) -or ($line[$rightCursorTmpQuote+1] -ne '"'))) {
+			for ($rightCursorTmpQuote = $rightCursorTmp + 1; $rightCursorTmpQuote -lt $line.Length; $rightCursorTmpQuote++) {
+				if (($line[$rightCursorTmpQuote] -eq '"') -and (($rightCursorTmpQuote -gt $line.Length) -or ($line[$rightCursorTmpQuote + 1] -ne '"'))) {
 					$rightCursorTmp = $rightCursorTmpQuote
 					break rightSearch
 				}
-				elseif (($line[$rightCursorTmpQuote] -eq "'") -and (($rightCursorTmpQuote -gt $line.Length) -or ($line[$rightCursorTmpQuote+1] -ne "'"))) {
+				elseif (($line[$rightCursorTmpQuote] -eq "'") -and (($rightCursorTmpQuote -gt $line.Length) -or ($line[$rightCursorTmpQuote + 1] -ne "'"))) {
 					$rightCursorTmp = $rightCursorTmpQuote
 					break rightSearch
 				}
@@ -615,8 +635,8 @@ function Find-CurrentPath {
 			break rightSearch
 		}
 	}
-	if ($leftCursorTmp -lt 0 -or $leftCursorTmp -gt $line.Length-1) { $leftCursorTmp = 0}
-	if ($rightCursorTmp -ge $line.Length) { $rightCursorTmp = $line.Length-1 }
+	if ($leftCursorTmp -lt 0 -or $leftCursorTmp -gt $line.Length - 1) { $leftCursorTmp = 0 }
+	if ($rightCursorTmp -ge $line.Length) { $rightCursorTmp = $line.Length - 1 }
 	$leftCursor.Value = $leftCursorTmp
 	$rightCursor.Value = $rightCursorTmp
 	$str = -join ($line[$leftCursorTmp..$rightCursorTmp])
@@ -624,15 +644,15 @@ function Find-CurrentPath {
 }
 
 function Invoke-FzfDefaultSystem {
-	param($ProviderPath,$DefaultOpts)
+	param($ProviderPath, $DefaultOpts)
 
 	$script:OverrideFzfDefaultOpts = [FzfDefaultOpts]::new($DefaultOpts)
 	$arguments = ''
 	if (-not $script:OverrideFzfDefaultOpts.Get().Contains('--height')) {
 		$arguments += "--height=40% "
-  	}
+	}
 
-	if ($script:UseFd -and $script:RunningInWindowsTerminal -and -not $script:OverrideFzfDefaultOpts.Get().Contains('--ansi')) {
+	if ($script:UseFd -and $script:AnsiCompatible -and -not $script:OverrideFzfDefaultOpts.Get().Contains('--ansi')) {
 		$arguments += "--ansi "
 	}
 	if ($script:UseWalker -and -not $script:OverrideFzfDefaultOpts.Get().Contains('--walker')) {
@@ -669,13 +689,15 @@ function Invoke-FzfDefaultSystem {
 		Get-Event -SourceIdentifier $stdOutEventId | `
 			Sort-Object -Property TimeGenerated | `
 			Where-Object { $null -ne $_.SourceEventArgs.Data } | ForEach-Object {
-				$result += $_.SourceEventArgs.Data
-				Remove-Event -EventIdentifier $_.EventIdentifier
-			}
+			$result += $_.SourceEventArgs.Data
+			Remove-Event -EventIdentifier $_.EventIdentifier
+		}
 		Remove-Event -SourceIdentifier $stdOutEventId
-	} catch {
+	}
+ catch {
 		# ignore errors
-	} finally {
+	}
+ finally {
 		if ($script:OverrideFzfDefaultCommand) {
 			$script:OverrideFzfDefaultCommand.Restore()
 			$script:OverrideFzfDefaultCommand = $null
@@ -841,33 +863,30 @@ function Invoke-FzfPsReadlineHandlerHistory {
 
 function Invoke-FzfPsReadlineHandlerHistoryArgs {
 	$result = @()
-	try
-    {
+	try {
 		$line = $null
 		$cursor = $null
 		[Microsoft.PowerShell.PSConsoleReadline]::GetBufferState([ref]$line, [ref]$cursor)
-		$line = $line.Insert($cursor,"{}") # add marker for fzf
+		$line = $line.Insert($cursor, "{}") # add marker for fzf
 
-        $contentTable = @{}
+		$contentTable = @{}
 		$reader = New-Object PSFzf.IO.ReverseLineReader -ArgumentList $((Get-PSReadlineOption).HistorySavePath)
 
 		$fileHist = @{}
 		$reader.GetEnumerator() | ForEach-Object {
 			if (-not $fileHist.ContainsKey($_)) {
-				$fileHist.Add($_,$true)
+				$fileHist.Add($_, $true)
 				[System.Management.Automation.PsParser]::Tokenize($_, [ref] $null)
 			}
-		} | Where-Object {$_.type -eq "commandargument" -or $_.type -eq "string"} |
-				ForEach-Object {
-					if (!$contentTable.ContainsKey($_.Content)) { $_.Content ; $contentTable[$_.Content] = $true }
-				} | Invoke-Fzf -Multi | ForEach-Object { $result += $_ }
+		} | Where-Object { $_.type -eq "commandargument" -or $_.type -eq "string" } |
+		ForEach-Object {
+			if (!$contentTable.ContainsKey($_.Content)) { $_.Content ; $contentTable[$_.Content] = $true }
+		} | Invoke-Fzf -Multi | ForEach-Object { $result += $_ }
 	}
-	catch
-	{
+	catch {
 		# catch custom exception
 	}
-	finally
-	{
+	finally {
 		$reader.Dispose()
 	}
 
@@ -876,55 +895,55 @@ function Invoke-FzfPsReadlineHandlerHistoryArgs {
 	[array]$result = $result | ForEach-Object {
 		# add quotes:
 		if ($_.Contains(" ") -or $_.Contains("`t")) {
-			"'{0}'" -f $_.Replace("'","''")
-		} else {
+			"'{0}'" -f $_.Replace("'", "''")
+		}
+		else {
 			$_
 		}
 	}
 	if ($result.Length -ge 0) {
-		[Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor,0,($result -join ' '))
+		[Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor, 0, ($result -join ' '))
 	}
 }
 
 function Invoke-FzfPsReadlineHandlerSetLocation {
 	$result = $null
-	try
-    {
+	try {
 		$script:OverrideFzfDefaults = [FzfDefaultOpts]::new($env:FZF_ALT_C_OPTS)
 
 		if ($null -eq $env:FZF_ALT_C_COMMAND) {
 			Invoke-Expression (Get-FileSystemCmd . -dirOnly) | Invoke-Fzf | ForEach-Object { $result = $_ }
-		} else {
+		}
+		else {
 			Invoke-Expression ($env:FZF_ALT_C_COMMAND) | Invoke-Fzf | ForEach-Object { $result = $_ }
 		}
-    }
-	catch
-	{
+	}
+	catch {
 		# catch custom exception
 	}
-	finally
-	{
+	finally {
 		if ($script:OverrideFzfDefaults) {
 			$script:OverrideFzfDefaults.Restore()
 			$script:OverrideFzfDefaults = $null
 		}
 	}
-    if (-not [string]::IsNullOrEmpty($result)) {
+	if (-not [string]::IsNullOrEmpty($result)) {
 		& $script:AltCCommand -Location $result
-        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-	} else {
+		[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+	}
+ else {
 		InvokePromptHack
 	}
 }
 
-function SetPsReadlineShortcut($Chord,[switch]$Override,$BriefDesc,$Desc,[scriptblock]$scriptBlock)
-{
+function SetPsReadlineShortcut($Chord, [switch]$Override, $BriefDesc, $Desc, [scriptblock]$scriptBlock) {
 	if ([string]::IsNullOrEmpty($Chord)) {
 		return $false
 	}
-	if ((Get-PSReadlineKeyHandler -Bound | Where-Object {$_.Key.ToLower() -eq $Chord}) -and -not $Override) {
+	if ((Get-PSReadlineKeyHandler -Bound | Where-Object { $_.Key.ToLower() -eq $Chord }) -and -not $Override) {
 		return $false
-	} else {
+	}
+ else {
 		Set-PSReadlineKeyHandler -Key $Chord -Description $Desc -BriefDescription $BriefDesc -ScriptBlock $scriptBlock
 		if ($(Get-PSReadLineOption).EditMode -eq [Microsoft.PowerShell.EditMode]::Vi) {
 			Set-PSReadlineKeyHandler -Key $Chord -ViMode Command -Description $Desc -BriefDescription $BriefDesc -ScriptBlock $scriptBlock
@@ -934,62 +953,69 @@ function SetPsReadlineShortcut($Chord,[switch]$Override,$BriefDesc,$Desc,[script
 }
 
 
-function FindFzf()
-{
+function FindFzf() {
 	if ($script:IsWindows) {
-		$AppNames = @('fzf-*-windows_*.exe','fzf.exe')
-	} else {
+		$AppNames = @('fzf-*-windows_*.exe', 'fzf.exe')
+	}
+ else {
 		if ($IsMacOS) {
-			$AppNames = @('fzf-*-darwin_*','fzf')
-		} elseif ($IsLinux) {
-			$AppNames = @('fzf-*-linux_*','fzf')
-		} else {
+			$AppNames = @('fzf-*-darwin_*', 'fzf')
+		}
+		elseif ($IsLinux) {
+			$AppNames = @('fzf-*-linux_*', 'fzf')
+		}
+		else {
 			throw 'Unknown OS'
 		}
 	}
 
-    # find it in our path:
-    $script:FzfLocation = $null
-    $AppNames | ForEach-Object {
-        if ($null -eq $script:FzfLocation) {
-            $result = Get-Command $_ -ErrorAction Ignore
-            $result | ForEach-Object {
-                $script:FzfLocation = Resolve-Path $_.Source
-            }
-        }
-    }
+	# find it in our path:
+	$script:FzfLocation = $null
+	$AppNames | ForEach-Object {
+		if ($null -eq $script:FzfLocation) {
+			$result = Get-Command $_ -ErrorAction Ignore
+			$result | ForEach-Object {
+				$script:FzfLocation = Resolve-Path $_.Source
+			}
+		}
+	}
 
-    if ($null -eq $script:FzfLocation) {
-        throw 'Failed to find fzf binary in PATH.  You can download a binary from this page: https://github.com/junegunn/fzf/releases'
-    }
+	if ($null -eq $script:FzfLocation) {
+		throw 'Failed to find fzf binary in PATH.  You can download a binary from this page: https://github.com/junegunn/fzf/releases'
+	}
 }
 
 $PsReadlineShortcuts = @{
-	PSReadlineChordProvider = [PSCustomObject]@{
-		'Chord' = "$PSReadlineChordProvider"
-		'BriefDesc' = 'Fzf Provider Select'
-		'Desc' = 'Run fzf for current provider based on current token'
-		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerProvider } };
-	PSReadlineChordReverseHistory = [PsCustomObject]@{
-		'Chord' = "$PSReadlineChordReverseHistory"
-		'BriefDesc' = 'Fzf Reverse History Select'
-		'Desc' = 'Run fzf to search through PSReadline history'
-		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerHistory } };
-	PSReadlineChordSetLocation = @{
-		'Chord' = "$PSReadlineChordSetLocation"
-		'BriefDesc' = 'Fzf Set Location'
-		'Desc' = 'Run fzf to select directory to set current location'
-		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerSetLocation } };
+	PSReadlineChordProvider           = [PSCustomObject]@{
+		'Chord'       = "$PSReadlineChordProvider"
+		'BriefDesc'   = 'Fzf Provider Select'
+		'Desc'        = 'Run fzf for current provider based on current token'
+		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerProvider }
+ };
+	PSReadlineChordReverseHistory     = [PsCustomObject]@{
+		'Chord'       = "$PSReadlineChordReverseHistory"
+		'BriefDesc'   = 'Fzf Reverse History Select'
+		'Desc'        = 'Run fzf to search through PSReadline history'
+		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerHistory }
+ };
+	PSReadlineChordSetLocation        = @{
+		'Chord'       = "$PSReadlineChordSetLocation"
+		'BriefDesc'   = 'Fzf Set Location'
+		'Desc'        = 'Run fzf to select directory to set current location'
+		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerSetLocation }
+ };
 	PSReadlineChordReverseHistoryArgs = @{
-		'Chord' = "$PSReadlineChordReverseHistoryArgs"
-		'BriefDesc' = 'Fzf Reverse History Arg Select'
-		'Desc' = 'Run fzf to search through command line arguments in PSReadline history'
-		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerHistoryArgs } };
-	PSReadlineChordTabCompletion = [PSCustomObject]@{
-		'Chord' = "Tab"
-		'BriefDesc' = 'Fzf Tab Completion'
-		'Desc' = 'Invoke Fzf for tab completion'
-		'ScriptBlock' = { Invoke-TabCompletion } };
+		'Chord'       = "$PSReadlineChordReverseHistoryArgs"
+		'BriefDesc'   = 'Fzf Reverse History Arg Select'
+		'Desc'        = 'Run fzf to search through command line arguments in PSReadline history'
+		'ScriptBlock' = { Invoke-FzfPsReadlineHandlerHistoryArgs }
+ };
+	PSReadlineChordTabCompletion      = [PSCustomObject]@{
+		'Chord'       = "Tab"
+		'BriefDesc'   = 'Fzf Tab Completion'
+		'Desc'        = 'Invoke Fzf for tab completion'
+		'ScriptBlock' = { Invoke-TabCompletion }
+ };
 }
 if (Get-Module -ListAvailable -Name PSReadline) {
 	$PsReadlineShortcuts.GetEnumerator() | ForEach-Object {
@@ -1000,31 +1026,31 @@ if (Get-Module -ListAvailable -Name PSReadline) {
 			$info.Chord = $null
 		}
 	}
-} else {
+}
+else {
 	Write-Warning "PSReadline module not found - keyboard handlers not installed"
 }
 
 FindFzf
 
-try
-{
-	$fzfVersion = $(& $script:FzfLocation --version).Replace(' (devel)','').Split('.')
+try {
+	$fzfVersion = $(& $script:FzfLocation --version).Split(' ')[0].Split('.')
 	$script:UseHeightOption = $fzfVersion.length -ge 2 -and `
-							  ([int]$fzfVersion[0] -gt 0 -or `
-							  [int]$fzfVersion[1] -ge 21) -and `
-							  $script:RunningInWindowsTerminald
+	([int]$fzfVersion[0] -gt 0 -or `
+			[int]$fzfVersion[1] -ge 21) -and `
+		$script:AnsiCompatible
 	$script:UseWalker = $fzfVersion.length -ge 2 -and `
-						([int]$fzfVersion[0] -gt 0 -or `
-						[int]$fzfVersion[1] -ge 48)
+	([int]$fzfVersion[0] -gt 0 -or `
+			[int]$fzfVersion[1] -ge 48)
 }
-catch
-{
+catch {
 	# continue
 }
 
 # check if we're running on Windows PowerShell. This method is faster than Get-Command:
 if ($(get-host).Version.Major -le 5) {
-    $script:PowershellCmd = 'powershell'
-} else {
-    $script:PowershellCmd = 'pwsh'
+	$script:PowershellCmd = 'powershell'
+}
+else {
+	$script:PowershellCmd = 'pwsh'
 }

--- a/PSFzf.Git.ps1
+++ b/PSFzf.Git.ps1
@@ -12,9 +12,9 @@ else {
     $script:pwshExec = "powershell"
 }
 
-$script:IsWindowsCheck = ($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows
+$script:IsPSWindows = ($PSVersionTable.PSVersion.Major -le 5)
 
-if ($RunningInWindowsTerminal -or -not $script:IsWindowsCheck) {
+if ($script:AnsiCompatible -or -not $script:IsPSWindows) {
     $script:filesString = '📁 Files'
     $script:hashesString = '🍡 Hashes'
     $script:allBranchesString = '🌳 All branches'
@@ -118,7 +118,7 @@ function IsInGitRepo() {
 }
 
 function Get-ColorAlways($setting = ' --color=always') {
-    if ($RunningInWindowsTerminal -or -not $IsWindowsCheck) {
+    if ($script:AnsiCompatible -or -not $IsPSWindows) {
         return $setting
     }
     else {


### PR DESCRIPTION
- Renamed variable $script:IsWindowsCheck to $script:IsPSWindows for clarity.
- Updated conditional checks to use $script:IsPSWindows instead of $script:IsWindowsCheck.
- Improved readability and maintainability of the code by consolidating Windows terminal checks.
