### PR TITLE
GitKeyBindings BriefDescription

### DIFF
--- a/PSFzf.Git.ps1
+++ b/PSFzf.Git.ps1
@@ -88,15 +88,46 @@ function SetGitKeyBindings($enable) {
         }
 
         if (Get-Command Set-PSReadLineKeyHandler -ErrorAction Ignore) {
-            @('ctrl+g,ctrl+b', 'Select Git branches via fzf', { Update-CmdLine $(Invoke-PsFzfGitBranches) }), `
-            @('ctrl+g,ctrl+f', 'Select Git files via fzf', { Update-CmdLine $(Invoke-PsFzfGitFiles) }), `
-            @('ctrl+g,ctrl+h', 'Select Git hashes via fzf', { Update-CmdLine $(Invoke-PsFzfGitHashes) }), `
-            @('ctrl+g,ctrl+p', 'Select Git pull requests via fzf', { Update-CmdLine $(Invoke-PsFzfGitPulLRequests) }), `
-            @('ctrl+g,ctrl+s', 'Select Git stashes via fzf', { Update-CmdLine $(Invoke-PsFzfGitStashes) }), `
-            @('ctrl+g,ctrl+t', 'Select Git tags via fzf', { Update-CmdLine $(Invoke-PsFzfGitTags) }) `
-            | ForEach-Object {
-                $script:GitKeyHandlers += $_[0]
-                Set-PSReadLineKeyHandler -Chord $_[0] -Description $_[1] -ScriptBlock $_[2]
+            @(
+                @{
+                    Chord            = 'ctrl+g,ctrl+b'
+                    BriefDescription = 'Fzf Git Branches Select'
+                    Description      = 'Select Git branches via fzf'
+                    ScriptBlock      = { Update-CmdLine $(Invoke-PsFzfGitBranches) }
+                }
+                @{
+                    Chord            = 'ctrl+g,ctrl+f'
+                    BriefDescription = 'Fzf Git Files Select'
+                    Description      = 'Select Git files via fzf'
+                    ScriptBlock      = { Update-CmdLine $(Invoke-PsFzfGitFiles) }
+                }
+                @{
+                    Chord            = 'ctrl+g,ctrl+h'
+                    BriefDescription = 'Fzf Git Hashes Select'
+                    Description      = 'Select Git hashes via fzf'
+                    ScriptBlock      = { Update-CmdLine $(Invoke-PsFzfGitHashes) }
+                }
+                @{
+                    Chord            = 'ctrl+g,ctrl+p'
+                    BriefDescription = 'Fzf Git Pull Requests Select'
+                    Description      = 'Select Git pull requests via fzf'
+                    ScriptBlock      = { Update-CmdLine $(Invoke-PsFzfGitPulLRequests) }
+                }
+                @{
+                    Chord            = 'ctrl+g,ctrl+s'
+                    BriefDescription = 'Fzf Git Stashes Select'
+                    Description      = 'Select Git stashes via fzf'
+                    ScriptBlock      = { Update-CmdLine $(Invoke-PsFzfGitStashes) }
+                }
+                @{
+                    Chord            = 'ctrl+g,ctrl+t'
+                    BriefDescription = 'Fzf Git Tags Select'
+                    Description      = 'Select Git tags via fzf'
+                    ScriptBlock      = { Update-CmdLine $(Invoke-PsFzfGitTags) }
+                }
+            ) | ForEach-Object {
+                $script:GitKeyHandlers += $_.Chord
+                Set-PSReadLineKeyHandler @_
             }
         }
         else {


### PR DESCRIPTION
Explicitly set the [`-BriefDescription`](https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlinekeyhandler#-briefdescription) parameter of [`Set-PSReadLineKeyHandler`](https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlinekeyhandler) to something descriptive when creating each Git key binding.

This additional metadata makes the output of [`Get-PSReadLineKeyHandler`](https://learn.microsoft.com/en-us/powershell/module/psreadline/get-psreadlinekeyhandler) and [`[Microsoft.PowerShell.PSConsoleReadLine]::ShowKeyBindings`](https://learn.microsoft.com/en-us/powershell/module/psreadline/about/about_psreadline_functions#showkeybindings) (i.e. `Ctr+Alt+?`) more useful, particularly when there is a number of key handlers the user is searching through.

## Before

```plaintext
[...]

User defined functions
======================

Key           Function     Description
---           --------     -----------
Ctrl+g,Ctrl+b CustomAction Select Git branches via fzf
Ctrl+g,Ctrl+f CustomAction Select Git files via fzf
Ctrl+g,Ctrl+h CustomAction Select Git hashes via fzf
Ctrl+g,Ctrl+p CustomAction Select Git pull requests via fzf
Ctrl+g,Ctrl+s CustomAction Select Git stashes via fzf
Ctrl+g,Ctrl+t CustomAction Select Git tags via fzf
```

## After

```plaintext
[...]

User defined functions
======================

Key           Function                     Description
---           --------                     -----------
Ctrl+g,Ctrl+b Fzf Git Branches Select      Select Git branches via fzf
Ctrl+g,Ctrl+f Fzf Git Files Select         Select Git files via fzf
Ctrl+g,Ctrl+h Fzf Git Hashes Select        Select Git hashes via fzf
Ctrl+g,Ctrl+p Fzf Git Pull Requests Select Select Git pull requests via fzf
Ctrl+g,Ctrl+s Fzf Git Stashes Select       Select Git stashes via fzf
Ctrl+g,Ctrl+t Fzf Git Tags Select          Select Git tags via fzf
```