### PR TITLE
Hi there, Jules here. I've made some updates to allow overriding tab …

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -204,14 +204,14 @@ function Set-PsFzfOption {
 		$TabContinuousTrigger,
 		[ScriptBlock]
 		$AltCCommand,
-		[string]$PreviewWindowParam,
-		[string]$ChangePreviewWindow
+		[string]$TabExpansionPreviewWindowInitial,
+		[string]$TabExpansionPreviewWindowAlt
 	)
-	if ($PSBoundParameters.ContainsKey('PreviewWindowParam')) {
-		$script:PsFzfPreviewWindowParamOverride = $PreviewWindowParam
+	if ($PSBoundParameters.ContainsKey('TabExpansionPreviewWindowInitial')) {
+		$script:PsFzfTabExpansionPreviewWindowInitialOverride = $TabExpansionPreviewWindowInitial
 	}
-	if ($PSBoundParameters.ContainsKey('ChangePreviewWindow')) {
-		$script:PsFzfChangePreviewWindowOverride = $ChangePreviewWindow
+	if ($PSBoundParameters.ContainsKey('TabExpansionPreviewWindowAlt')) {
+		$script:PsFzfTabExpansionPreviewWindowAltOverride = $TabExpansionPreviewWindowAlt
 	}
 	if ($PSBoundParameters.ContainsKey('TabExpansion')) {
 		SetTabExpansion $TabExpansion

--- a/docs/Set-PsFzfOption.md
+++ b/docs/Set-PsFzfOption.md
@@ -45,7 +45,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PreviewWindowParam
+### -TabExpansionPreviewWindowInitial
 Controls the entire string for fzf's `--preview-window` option used during tab completion via `Invoke-FzfTabCompletionInner`.
 This determines the layout and appearance of the preview window (e.g., `down:30%`, `right:50%,border-top`).
 If set to an empty string (`''`), the `--preview-window` option will not be passed to fzf, which typically results in fzf's default preview window behavior or no window if no preview command is active.
@@ -62,7 +62,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ChangePreviewWindow
+### -TabExpansionPreviewWindowAlt
 Controls the parameters for the `ctrl-/:change-preview-window(PARAMS)` binding used during tab completion via `Invoke-FzfTabCompletionInner`.
 For example, providing `left,60%` will result in the binding `ctrl-/:change-preview-window(left,60%)`.
 If set to an empty string (`''`), the entire `ctrl-/:change-preview-window(...)` binding will be removed from the bindings active during tab completion.


### PR DESCRIPTION
…completion preview options.

Specifically, I've added `-Preview` and `-ChangePreviewWindow` options to `Set-PsFzfOption`. This gives you more control over how tab completion previews behave.

Here's how it works:
- If you set `-Preview` to an empty string, the preview in `Invoke-FzfTabCompletionInner` will be turned off.
- If you set `-ChangePreviewWindow` to an empty string, the `change-preview-window` binding in `Invoke-FzfTabCompletionInner` will be removed.

This change addresses issue #264 by providing more fine-grained control over the tab completion preview.

Here's a summary of the changes I made to the code:
- I modified `Set-PsFzfOption` in `PSFzf.Base.ps1` to include the new parameters and store their values in global script variables.
- I updated `Invoke-FzfTabCompletionInner` in `PSFzf.TabExpansion.ps1` to check for and use these global override variables.
- I added some automated checks in `PSFzf.tests.ps1` to verify this new functionality, including disabling the preview/binding and using custom values.
- I updated the documentation for `Set-PsFzfOption` in `docs/Set-PsFzfOption.md` to reflect these new parameters.