### PR TITLE
Remove FZF_VERSION from CI and Deploy workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,13 +6,11 @@ jobs:
   linux:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install needed software
       run: ./.github/scripts/Install.ps1
-      env:
-        FZF_VERSION: 0.24.3
       shell: pwsh
     - name: Build PSFzf-Binary
       run: ./.github/scripts/Build.ps1
@@ -20,36 +18,32 @@ jobs:
     - name: Run tests
       run: ./.github/scripts/Tests.ps1
       shell: pwsh
-      
+
 
   Mac:
 
     runs-on: macOS-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install needed software
       run: ./.github/scripts/Install.ps1
-      env:
-        FZF_VERSION: 0.24.3
       shell: pwsh
     - name: Build PSFzf-Binary
       run: ./.github/scripts/Build.ps1
       shell: pwsh
     - name: Run tests
       run: ./.github/scripts/Tests.ps1
-      shell: pwsh      
-  
+      shell: pwsh
+
   windows:
 
     runs-on: windows-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install needed software
       run: ./.github/scripts/Install.ps1
-      env:
-        FZF_VERSION: 0.24.3
       shell: powershell
     - name: Build PSFzf-Binary
       run: |
@@ -59,4 +53,4 @@ jobs:
     - name: Run tests
       run: ./.github/scripts/Tests.ps1
       shell: powershell
-      
+

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -6,15 +6,13 @@ on:
 
 jobs:
     windows:
-    
+
         runs-on: windows-latest
-    
+
         steps:
         - uses: actions/checkout@v1
         - name: Install needed software
           run: ./.github/scripts/Install.ps1
-          env:
-            FZF_VERSION: 0.24.3
           shell: pwsh
         - name: Build PSFzf-Binary
           run: ./.github/scripts/Build.ps1


### PR DESCRIPTION
Eliminate the FZF_VERSION environment variable from the CI and Deploy workflows to streamline the setup process.