### PR TITLE
Respect TabExpansion2 by passing a [PowerShell] instance to CompleteInput

### DIFF
--- a/PSFzf.TabExpansion.ps1
+++ b/PSFzf.TabExpansion.ps1
@@ -244,8 +244,18 @@ function script:Invoke-FzfTabCompletionInner() {
         return $false
     }
 
+    $runspace = Get-Runspace
+    $runspaceIsRemote = $null -ne $runspace -and $null -ne $runspace.ConnectionInfo
+    if (-not $runspaceIsRemote) {
+        $ps = [System.Management.Automation.PowerShell]::Create('CurrentRunspace')
+    }
+    else {
+        $ps = [System.Management.Automation.PowerShell]::Create()
+        $ps.Runspace = $runspace
+    }
+
     try {
-        $completions = [System.Management.Automation.CommandCompletion]::CompleteInput($line, $cursor, @{})
+        $completions = [System.Management.Automation.CommandCompletion]::CompleteInput($line, $cursor, @{}, $ps)
     }
     catch {
         # some custom tab completions will cause CompleteInput() to throw, so we gracefully handle those cases.


### PR DESCRIPTION
Theoretically fixes #355 

**I haven't had a chance to test this** though I've manually run similar code in an interactive session to confirm it calls TabExpansion2 and receives customized completion items.

Logic is ported from PSReadLine: https://github.com/PowerShell/PSReadLine/blob/6fa5711700c830335d36c8d54b7c3dadfcb0d181/PSReadLine/Completion.cs#L282-L309

I omitted the bits about setting a `_directorySeparator`; not 100% sure what that does, but I think it's a PSReadLine-specific thing.