### PR TITLE
Recommend installing from winget, not chocolatey, because chocolatey's fzf package is unmaintained and outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Follow the [installation instructions for fzf](https://github.com/junegunn/fzf#i
 
 ### Windows
 
-The latest version of `fzf` is available via [Chocolatey](https://chocolatey.org/packages/fzf), or you can download the `fzf` binary and place it in your path.  Run `Get-Command fzf*.exe` to verify that PowerShell can find the executable.
+The latest version of `fzf` is available via [winget](https://winstall.app/apps/junegunn.fzf), or you can download the `fzf` binary and place it in your path.  Run `Get-Command fzf*.exe` to verify that PowerShell can find the executable.
 
 PSFzf has been tested under PowerShell 5.0, 6.0, and 7.0.
 


### PR DESCRIPTION
At the time of writing:

fzf 0.67.0 is available from winget: https://winstall.app/apps/junegunn.fzf
Chocolatey is on version 0.59.0: https://community.chocolatey.org/packages/fzf

The latest version 0.67.0: https://github.com/junegunn/fzf/releases

Winget is bundled with modern versions of Windows.

```
$ winget install --id=junegunn.fzf  -e
$ fzf --version
0.67.0 (2ab923f3)
```