### PR TITLE
Join multiline result from command history

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -930,6 +930,9 @@ function Invoke-FzfPsReadlineHandlerHistory {
 	$cursor = $bufferState.Cursor
 
 	$result = Get-PickedHistory -Query $line -UsePSReadLineHistory
+	if ($result -is [system.array]) {
+		$result = $result -join "```n"
+	}
 
 	InvokePromptHack
 


### PR DESCRIPTION
When a multi-line command in command history is chosen, `Invoke-Fzf` at this line returns an array of strings:
https://github.com/kelleyma49/PSFzf/blob/d5af3d30fc0312f2c1c561071e61433dbcead30d/PSFzf.Base.ps1#L897

Currently, PSFzf fails with error message:

> An exception occurred in custom key handler, see $error for more information: Cannot process argument transformation on parameter 'ReplacementText'. Cannot convert value to type System.String.

This PR fixes this error.