### PR TITLE
Ensure Removal of Event Subscribers Post-Execution

### DIFF
--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -735,20 +735,22 @@ function Invoke-FzfDefaultSystem {
 		$process.BeginOutputReadLine() | Out-Null
 		$process.WaitForExit()
 
-		Get-Event -SourceIdentifier $stdOutEventId | `
-			Sort-Object -Property TimeGenerated | `
-			Where-Object { $null -ne $_.SourceEventArgs.Data } | ForEach-Object {
-			$result += $_.SourceEventArgs.Data
-			Remove-Event -EventIdentifier $_.EventIdentifier
-		}
-		Remove-Event -SourceIdentifier $stdOutEventId
+		Get-Event -SourceIdentifier $stdOutEventId |
+			Where-Object { $null -ne $_.SourceEventArgs.Data } |
+			Sort-Object -Property TimeGenerated |
+			ForEach-Object { $result += $_.SourceEventArgs.Data }
 	}
- catch {
-		# ignore errors
-	}
- finally {
+	finally {
 		try {
+			Get-Event -SourceIdentifier $stdOutEventId -ErrorAction SilentlyContinue | ForEach-Object {
+				Remove-Event -EventIdentifier $_.EventIdentifier -ErrorAction SilentlyContinue
+			}
 			Unregister-Event -SourceIdentifier $stdOutEventId -ErrorAction SilentlyContinue
+
+			if ($null -ne $stdOutEvent) {
+				Stop-Job -Job $stdOutEvent -ErrorAction SilentlyContinue
+				Remove-Job -Job $stdOutEvent -Force -ErrorAction SilentlyContinue
+			}
 		}
 		finally {} # ignore errors
 

--- a/PSFzf.Base.ps1
+++ b/PSFzf.Base.ps1
@@ -497,20 +497,6 @@ function Invoke-Fzf {
 				# do nothing
 			}
 
-			try {
-				#$stdOutEventId,$exitedEventId | ForEach-Object {
-				#	Unregister-Event $_ -ErrorAction SilentlyContinue
-				#}
-
-				$stdOutEvent, $exitedEvent | ForEach-Object {
-					Stop-Job $_  -ErrorAction SilentlyContinue
-					Remove-Job $_ -Force  -ErrorAction SilentlyContinue
-				}
-			}
-			catch {
-
-			}
-
 			# events seem to be generated out of order - therefore, we need sort by time created. For example,
 			# -print-query and -expect and will be outputted first if specified on the command line.
 			Get-Event -SourceIdentifier $stdOutEventId | `
@@ -519,6 +505,20 @@ function Invoke-Fzf {
 				Write-Output $_.SourceEventArgs.Data
 				Remove-Event -EventIdentifier $_.EventIdentifier
 			}
+
+			try {
+				$stdOutEventId, $exitedEventId | ForEach-Object {
+					Unregister-Event -SourceIdentifier $_ -ErrorAction SilentlyContinue
+				}
+
+				$stdOutEvent, $exitedEvent |
+					Where-Object { $null -ne $_ } |
+					ForEach-Object {
+						Stop-Job -Job $_ -ErrorAction SilentlyContinue
+						Remove-Job -Job $_ -Force -ErrorAction SilentlyContinue
+					}
+			}
+			finally {}
 		}
 		$checkProcessStatus = [scriptblock] {
 			if ($processHasExited.flag -or $process.HasExited) {
@@ -747,6 +747,11 @@ function Invoke-FzfDefaultSystem {
 		# ignore errors
 	}
  finally {
+		try {
+			Unregister-Event -SourceIdentifier $stdOutEventId -ErrorAction SilentlyContinue
+		}
+		finally {} # ignore errors
+
 		if ($script:OverrideFzfDefaultCommand) {
 			$script:OverrideFzfDefaultCommand.Restore()
 			$script:OverrideFzfDefaultCommand = $null

--- a/PSFzf.tests.ps1
+++ b/PSFzf.tests.ps1
@@ -210,6 +210,50 @@ Describe 'Invoke-PsFzfRipgrep' {
     }
 }
 
+Describe 'Invoke-Fzf event cleanup' {
+	InModuleScope PsFzf {
+		AfterEach {
+			Get-EventSubscriber | Where-Object {
+				$_.SourceIdentifier -like 'PsFzf*Eh-*' -or
+				$_.SourceIdentifier -like 'Invoke-FzfDefaultSystem-PsFzfStdOutEh-*'
+			} | ForEach-Object {
+				Unregister-Event -SourceIdentifier $_.SourceIdentifier -ErrorAction SilentlyContinue
+			}
+		}
+
+		It 'Should not leave event subscribers after Invoke-Fzf completes' {
+			$before = @(Get-EventSubscriber | Where-Object {
+					$_.SourceIdentifier -like 'PsFzf*Eh-*'
+				} | Select-Object -ExpandProperty SourceIdentifier | Sort-Object)
+
+			'file1.txt' | Invoke-Fzf -Select1 -Exit0 -Filter 'file1.txt' | Out-Null
+
+			$after = @(Get-EventSubscriber | Where-Object {
+					$_.SourceIdentifier -like 'PsFzf*Eh-*'
+				} | Select-Object -ExpandProperty SourceIdentifier | Sort-Object)
+
+			Compare-Object -ReferenceObject $before -DifferenceObject $after |
+				Should -BeNullOrEmpty
+		}
+
+		It 'Should not leave event subscribers after Invoke-FzfDefaultSystem completes' {
+			$providerPath = (Resolve-Path $TestDrive).Path
+			$before = @(Get-EventSubscriber | Where-Object {
+					$_.SourceIdentifier -like 'Invoke-FzfDefaultSystem-PsFzfStdOutEh-*'
+				} | Select-Object -ExpandProperty SourceIdentifier | Sort-Object)
+
+			Invoke-FzfDefaultSystem -ProviderPath $providerPath -DefaultOpts '--filter=file1.txt' | Out-Null
+
+			$after = @(Get-EventSubscriber | Where-Object {
+					$_.SourceIdentifier -like 'Invoke-FzfDefaultSystem-PsFzfStdOutEh-*'
+				} | Select-Object -ExpandProperty SourceIdentifier | Sort-Object)
+
+			Compare-Object -ReferenceObject $before -DifferenceObject $after |
+				Should -BeNullOrEmpty
+		}
+	}
+}
+
 Describe 'Invoke-FuzzySetLocation' {
 	InModuleScope PsFzf {
 


### PR DESCRIPTION
Addressing raised issue #378, added _Unregister-Event_ calls during cleanup process for _**Invoke-Fzf**_ and _**Invoke-FzfDefaultSystem**_ to make sure there aren't hanging event subscribers in the session post-execution.

Also created a couple of tests verifying behavior, and did a tiny bit of fix-ups in the existing cleanup process for both functions.