### PR TITLE
Fix Invoke-FuzzyScoop for nested Scoop bucket manifests

### DIFF
--- a/PSFzf.Functions.ps1
+++ b/PSFzf.Functions.ps1
@@ -328,8 +328,8 @@ function Invoke-FuzzyScoop() {
         $apps = New-Object System.Collections.ArrayList
         Get-ChildItem "$(Split-Path $scoopexists.Path)\..\buckets" | ForEach-Object {
             $bucket = $_.Name
-            Get-ChildItem "$($_.FullName)\bucket" | ForEach-Object {
-                $apps.Add($bucket + '/' + ($_.Name -replace '.json', '')) > $null
+            Get-ChildItem "$($_.FullName)\bucket" -Recurse -File -Filter "*.json" | ForEach-Object {
+                $apps.Add($bucket + '/' + $_.BaseName) > $null
             }
         }
 


### PR DESCRIPTION
Invoke-FuzzyScoop currently enumerates only the direct children of each bucket's `bucket` directory. This works for traditional flat buckets, but it treats subdirectories as apps when a bucket organizes manifests in nested folders.

Scoop supports manifests in subfolders, and some buckets use this layout. For example, abgox/abyss stores manifests under paths such as:

bucket/a/abgox/abgox.scoop-i18n.json

Before this change, `fs` shows entries like:

abyss/a
abyss/z

and the preview runs `scoop info abyss/a`, which fails.

This change recursively enumerates only `*.json` files and uses the manifest BaseName as the app name. Flat buckets continue to work as before, while nested buckets are now supported.